### PR TITLE
disable e-matching by default, adding option to turn it on

### DIFF
--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -40,7 +40,10 @@ opt_seed.set_callback(set_seed)
 
 def set_macro_finder(truth):
     z3.set_param('smt.macro_finder',truth)
-    
+
+def set_ematching(truth):
+    z3.set_param('smt.ematching',truth)
+
 opt_incremental = iu.BooleanParameter("incremental",True)
 opt_show_vcs = iu.BooleanParameter("show_vcs",False)
 
@@ -48,6 +51,10 @@ opt_show_vcs = iu.BooleanParameter("show_vcs",False)
 opt_macro_finder = iu.BooleanParameter("macro_finder",True)
 set_macro_finder(True)
 opt_macro_finder.set_callback(set_macro_finder)
+
+opt_ematching = iu.BooleanParameter("ematching",False)
+set_ematching(False)
+opt_ematching.set_callback(set_ematching)
 
 def set_use_native_enums(t):
     global use_z3_enums


### PR DESCRIPTION
We've been working on a model that produces queries that cause Z3 to diverge. On a hunch, I tried running the same `.smt2` query with Z3's e-matching quantifier-instantiation strategy disabled, and it now returns a result in a (relatively) timely fashion.

If I understand correctly, checking formulas in FAU should really never be using e-matching anyways, right? Or is it supposed to be harmless to have it turned on anyways, and just assume it doesn't get used (or only gets used in an interleaved fashion with MBQI, or something)? Anyway, it appears to risk divergence to have it turned on, at least in some cases!

(Interestingly, this only works if I also run ivy with `incremental=false`, which I do not really understand the effects of in terms of quantifier instantiation -- or any other bit of Z3 internals -- but it at least does work then!)