### PR TITLE
Convert to python3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "submodules/z3"]
-	path = submodules/z3
-	url = https://github.com/kenmcmil/z3.git
 [submodule "submodules/picotls"]
 	path = submodules/picotls
 	url = https://github.com/h2o/picotls.git

--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 Ivy needs:
 
-python 2.7
-IPython 3.2
+python 3.8
+IPython 7.13
 ply (python lex yacc)
 Z3 python interface (import z3 should work)
 pygraphviz 1.3.1 (which requires graphviz)

--- a/build_submodules.py
+++ b/build_submodules.py
@@ -3,7 +3,7 @@ import os
 import platform
 
 def do_cmd(cmd):
-    print cmd
+    print(cmd)
     status = os.system(cmd)
     if status:
         exit(1)
@@ -12,7 +12,7 @@ def make_dir_exist(dir):
     if not os.path.exists(dir):
         os.mkdir(dir)
     elif not os.path.isdir(dir):
-        print "cannot create directory {}".format(dir)
+        print("cannot create directory {}".format(dir))
         exit(1)
         
 
@@ -39,14 +39,14 @@ def find_vs():
             vcvars = dir + '\\VC\\vcvars64.bat'
             if os.path.exists(vcvars):
                 return vcvars
-    print 'Cannot find a suitable version of Visual Studio (require 10.0-15.0 or 2017 or 2019)'
+    print('Cannot find a suitable version of Visual Studio (require 10.0-15.0 or 2017 or 2019)')
 
 def build_z3():
 
     cwd = os.getcwd()
 
     if not os.path.exists('submodules/z3'):
-        print "submodules/z3 not found. try 'git submodule update; git submodule update'"
+        print("submodules/z3 not found. try 'git submodule update; git submodule update'")
         exit(1)
 
     os.chdir('submodules/z3')
@@ -91,7 +91,7 @@ def install_z3():
 def build_picotls():
         
     if not os.path.exists('submodules/picotls'):
-        print "submodules/picotls not found. try 'git submodule update; git submodule update'"
+        print("submodules/picotls not found. try 'git submodule update; git submodule update'")
         exit(1)
 
     cwd = os.getcwd()

--- a/build_submodules.py
+++ b/build_submodules.py
@@ -41,52 +41,6 @@ def find_vs():
                 return vcvars
     print('Cannot find a suitable version of Visual Studio (require 10.0-15.0 or 2017 or 2019)')
 
-def build_z3():
-
-    cwd = os.getcwd()
-
-    if not os.path.exists('submodules/z3'):
-        print("submodules/z3 not found. try 'git submodule update; git submodule update'")
-        exit(1)
-
-    os.chdir('submodules/z3')
-
-    ivydir = os.path.join(cwd,'ivy')
-
-
-    if platform.system() != 'Windows':
-        cmd = 'python scripts/mk_make.py --python --prefix {} --pypkgdir {}/'.format(cwd,ivydir)
-    else:
-        cmd = 'python scripts/mk_make.py -x --python --pypkgdir {}/'.format(ivydir)
-
-    do_cmd(cmd)
-
-    os.chdir('build')
-
-    if platform.system() == 'Windows':
-        do_cmd('"{}" & nmake'.format(find_vs()))
-    else:
-        do_cmd('make -j 4')
-        do_cmd('make install')
-
-    os.chdir(cwd)
-
-def install_z3():
-
-    make_dir_exist('ivy/lib')
-    make_dir_exist('ivy/z3')
-
-    if platform.system() == 'Windows':
-        do_cmd('copy submodules\\z3\\src\\api\\*.h ivy\\include')
-        do_cmd('copy "submodules\\z3\\src\\api\\c++\\*.h" ivy\\include')
-        do_cmd('copy submodules\\z3\\build\\*.dll ivy\\lib')
-        do_cmd('copy submodules\\z3\\build\\*.lib ivy\\lib')
-        do_cmd('copy submodules\\z3\\build\\*.dll ivy\\z3')
-        do_cmd('copy submodules\\z3\\build\\python\\z3\\*.py ivy\\z3')
-    else:
-        do_cmd('cp include/*.h ivy/include')
-        do_cmd('cp lib/*.so ivy/lib')
-        do_cmd('cp lib/*.so ivy/z3')
 
 def build_picotls():
         
@@ -149,8 +103,6 @@ def build_v2_compiler():
     os.chdir(cwd)
     
 if __name__ == "__main__":
-    build_z3()
-    install_z3()
     build_picotls()
     install_picotls()
     

--- a/build_v2_compiler.py
+++ b/build_v2_compiler.py
@@ -3,7 +3,7 @@ import os
 import platform
 
 def do_cmd(cmd):
-    print cmd
+    print(cmd)
     status = os.system(cmd)
     if status:
         exit(1)
@@ -12,7 +12,7 @@ def make_dir_exist(dir):
     if not os.path.exists(dir):
         os.mkdir(dir)
     elif not os.path.isdir(dir):
-        print "cannot create directory {}".format(dir)
+        print("cannot create directory {}".format(dir))
         exit(1)
         
 
@@ -39,7 +39,7 @@ def find_vs():
             vcvars = dir + '\\VC\\vcvars64.bat'
             if os.path.exists(vcvars):
                 return vcvars
-    print 'Cannot find a suitable version of Visual Studio (require 10.0-15.0 or 2017 or 2019)'
+    print('Cannot find a suitable version of Visual Studio (require 10.0-15.0 or 2017 or 2019)')
 
 
 def build_v2_compiler():

--- a/doc/examples/account2_expect.py
+++ b/doc/examples/account2_expect.py
@@ -10,5 +10,5 @@ def run(name,opts,res):
         child.expect('assumption failed')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/account3_expect.py
+++ b/doc/examples/account3_expect.py
@@ -21,5 +21,5 @@ def run(name,opts,res):
         child.expect('0')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/account_expect.py
+++ b/doc/examples/account_expect.py
@@ -25,5 +25,5 @@ def run(name,opts,res):
         child.expect('65535')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/helloworld_expect.py
+++ b/doc/examples/helloworld_expect.py
@@ -10,5 +10,5 @@ def run(name,opts,res):
         child.expect('< world')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/leader_election_ring_repl_expect.py
+++ b/doc/examples/leader_election_ring_repl_expect.py
@@ -19,5 +19,5 @@ def run(name,opts,res):
         child.expect(r'assumption failed')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/leader_election_ring_repl_iso_impl_expect.py
+++ b/doc/examples/leader_election_ring_repl_iso_impl_expect.py
@@ -19,5 +19,5 @@ def run(name,opts,res):
         child.expect(r'serv.elect\(1\)')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/leader_election_ring_udp2_expect.py
+++ b/doc/examples/leader_election_ring_udp2_expect.py
@@ -10,7 +10,7 @@ def run(name,opts,res):
         child[0].expect(r'< serv.elect')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False
     finally:
         for idx in range(2):

--- a/doc/examples/leader_election_ring_udp_expect.py
+++ b/doc/examples/leader_election_ring_udp_expect.py
@@ -11,7 +11,7 @@ def run(name,opts,res):
         child[0].expect(r'< serv.elect')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False
     finally:
         for idx in range(2):

--- a/doc/examples/paraminit3_expect.py
+++ b/doc/examples/paraminit3_expect.py
@@ -9,7 +9,7 @@ def run(name,opts,res):
         child.sendline('foo.get_bit')
         child.expect(r'= 1')
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False
     finally:
         child.close()
@@ -21,7 +21,7 @@ def run(name,opts,res):
         child.expect(r'= 0')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False
     finally:
         child.close()

--- a/doc/examples/paraminit_expect.py
+++ b/doc/examples/paraminit_expect.py
@@ -10,7 +10,7 @@ def run(name,opts,res):
         child.expect(r'= 0')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False
     finally:
         child.close()

--- a/doc/examples/quic/test/outliers.py
+++ b/doc/examples/quic/test/outliers.py
@@ -6,7 +6,7 @@ from tabulate import tabulate
 def main():
     import sys
     def usage():
-        print "usage: \n  {} <file>.dat".format(sys.argv[0])
+        print("usage: \n  {} <file>.dat".format(sys.argv[0]))
         sys.exit(1)
     if len(sys.argv) != 2:
         usage()
@@ -38,7 +38,7 @@ def main():
         fun = lambda x: x[0]
         scands = sorted(cands,key=fun)
         data = [cand[1:] for cand in scands[-3:]]
-        print tabulate(data,tablefmt="fancy_grid")
+        print(tabulate(data,tablefmt="fancy_grid"))
 
 
 if __name__ == '__main__':

--- a/doc/examples/quic/test/plot.py
+++ b/doc/examples/quic/test/plot.py
@@ -19,7 +19,7 @@ def plot(fn,column,col):
 def main():
     import sys
     def usage():
-        print "usage: \n  {} <file>.dat column ".format(sys.argv[0])
+        print("usage: \n  {} <file>.dat column ".format(sys.argv[0]))
         sys.exit(1)
     if len(sys.argv) != 3:
         usage()

--- a/doc/examples/quic/test/show.py
+++ b/doc/examples/quic/test/show.py
@@ -6,7 +6,7 @@ from tabulate import tabulate
 def main():
     import sys
     def usage():
-        print "usage: \n  {} <file>.dat [field...]".format(sys.argv[0])
+        print("usage: \n  {} <file>.dat [field...]".format(sys.argv[0]))
         sys.exit(1)
     if len(sys.argv) < 2:
         usage()
@@ -25,7 +25,7 @@ def main():
                     sys.stderr.write('unknown field "{}"\n'.format(f))
                     exit(1)
             rows.append([row[f] for f in fields])
-        print tabulate(rows,tablefmt="fancy_grid",headers=fields)
+        print(tabulate(rows,tablefmt="fancy_grid",headers=fields))
 
 
 if __name__ == '__main__':

--- a/doc/examples/quic/test/stats.py
+++ b/doc/examples/quic/test/stats.py
@@ -38,7 +38,7 @@ def doit(fbase,out):
         try:
             f = open(fn,'r')
         except:
-            print "not found: %s" % fn
+            print("not found: %s" % fn)
             sys.exit(1)
 
         with iu.ErrorPrinter():
@@ -63,7 +63,7 @@ def doit(fbase,out):
 def main():
     import sys
     def usage():
-        print "usage: \n  {} <file>.iev ".format(sys.argv[0])
+        print("usage: \n  {} <file>.iev ".format(sys.argv[0]))
         sys.exit(1)
     if len(sys.argv) != 2:
         usage()

--- a/doc/examples/quic/test/test.py
+++ b/doc/examples/quic/test/test.py
@@ -55,7 +55,7 @@ client_tests = [
 
 import sys
 def usage():
-    print """usage:
+    print("""usage:
     {} [option...]
 options:
     dir=<output directory to create>
@@ -64,7 +64,7 @@ options:
     test=<test name pattern>
     stats={{true,false}}
     run={{true,false}}
-""".format(sys.argv[0])
+""".format(sys.argv[0]))
     sys.exit(1)
 
 dirpath = None
@@ -122,7 +122,7 @@ if dirpath is None:
             break
         idx = idx + 1
 
-print 'output directory: {}'.format(dirpath)
+print('output directory: {}'.format(dirpath))
             
 try:
     patre = re.compile(pat)
@@ -137,7 +137,7 @@ except OSError:
     exit(1)
 
 # extra_args = ['server_addr=0xc0a80101','client_addr=0xc0a80102'] if server_name == 'winquic' else []
-extra_args = [oname+'='+oval for oname,oval in ivy_options.iteritems() if oval is not None]
+extra_args = [oname+'='+oval for oname,oval in ivy_options.items() if oval is not None]
 
 svrd = dict(clients if test_client else servers)
 if server_name not in svrd:
@@ -148,8 +148,8 @@ server_dir,server_cmd = svrd[server_name]
 if not run:
     server_cmd = 'true'
 
-print 'implementation directory: {}'.format(server_dir)
-print 'implementation command: {}'.format(server_cmd)
+print('implementation directory: {}'.format(server_dir))
+print('implementation command: {}'.format(server_cmd))
 
 
 def open_out(name):
@@ -159,40 +159,40 @@ def sleep():
     return
     if server_name == 'winquic':
         st = 20
-        print 'sleeping for {}'.format(st)
+        print('sleeping for {}'.format(st))
         time.sleep(st)
 
 class Test(object):
     def __init__(self,dir,args):
         self.dir,self.name,self.res,self.opts = dir,args[0],args[-1],args[1:-1]
     def run(self,seq):
-        print '{}/{} ({}) ...'.format(self.dir,self.name,seq)
+        print('{}/{} ({}) ...'.format(self.dir,self.name,seq))
         status = self.run_expect(seq)
-        print 'PASS' if status else 'FAIL'
+        print('PASS' if status else 'FAIL')
         return status
     def run_expect(self,seq):
         for pc in self.preprocess_commands():
-            print 'executing: {}'.format(pc)
+            print('executing: {}'.format(pc))
             child = spawn(pc)
             child.logfile = sys.stdout
             child.expect(pexpect.EOF)
             child.close()
             if child.exitstatus != 0:
 #            if child.wait() != 0:
-                print child.before
+                print(child.before)
                 return False
         with open_out(self.name+str(seq)+'.out') as out:
             with open_out(self.name+str(seq)+'.err') as err:
                 with open_out(self.name+str(seq)+'.iev') as iev:
                     if run:
                         scmd = 'sleep 1; ' + server_cmd if test_client else server_cmd.split() 
-                        print 'implementation command: {}'.format(scmd)
+                        print('implementation command: {}'.format(scmd))
                         server = subprocess.Popen(scmd,
                                                   cwd=server_dir,
                                                   stdout=out,
                                                   stderr=err,
                                                   shell=test_client)
-                        print 'server pid: {}'.format(server.pid)
+                        print('server pid: {}'.format(server.pid))
                     try:
                         ok = self.expect(seq,iev)
                     except KeyboardInterrupt:
@@ -204,13 +204,13 @@ class Test(object):
                         retcode = server.wait()
                         if retcode != -15 and retcode != 0:  # if not exit on SIGTERM...
                             iev.write('server_return_code({})\n'.format(retcode))
-                            print "server return code: {}".format(retcode)
+                            print("server return code: {}".format(retcode))
                             return False
                     return ok
             
     def expect(self,seq,iev):
         command = self.command(seq)
-        print command
+        print(command)
         if platform.system() != 'Windows':
             oldcwd = os.getcwd()
             os.chdir(self.dir)
@@ -219,17 +219,17 @@ class Test(object):
             try:
                 retcode = proc.wait()
             except KeyboardInterrupt:
-                print 'terminating client process {}'.format(proc.pid)
+                print('terminating client process {}'.format(proc.pid))
                 proc.terminate()
                 raise KeyboardInterrupt
             if retcode == 124:
-                print 'timeout'
+                print('timeout')
                 iev.write('timeout\n')
                 sleep()
                 return False
             if retcode != 0:
                 iev.write('ivy_return_code({})\n'.format(retcode))
-                print 'client return code: {}'.format(retcode)
+                print('client return code: {}'.format(retcode))
             sleep()
             return retcode == 0
         else:
@@ -241,19 +241,19 @@ class Test(object):
             try:
                 child.expect(self.res,timeout=100)
                 child.close()
-                print "tester exit status: {}".format(child.exitstatus)
-                print "tester signal status: {}".format(child.signalstatus)
+                print("tester exit status: {}".format(child.exitstatus))
+                print("tester signal status: {}".format(child.signalstatus))
                 return True
             except pexpect.EOF:
-                print child.before
+                print(child.before)
                 return False
             except pexpect.exceptions.TIMEOUT:
-                print 'timeout'
+                print('timeout')
                 child.terminate()
                 child.close()
                 return False
             except KeyboardInterrupt:
-                print 'terminating tester process'
+                print('terminating tester process')
                 child.kill(signal.SIGINT)
                 child.close()
                 raise KeyboardInterrupt
@@ -294,11 +294,11 @@ try:
                 stats.doit(test.name,out)
                 os.chdir(save)
     if num_failures:
-        print 'error: {} tests(s) failed'.format(num_failures)
+        print('error: {} tests(s) failed'.format(num_failures))
     else:
-        print 'OK'
+        print('OK')
 except KeyboardInterrupt:
-    print 'terminated'
+    print('terminated')
 
 # for checkd in checks:
 #     dir,checkl = checkd

--- a/doc/examples/rest/extract.py
+++ b/doc/examples/rest/extract.py
@@ -206,14 +206,14 @@ def main():
         
     def_refs = collections.defaultdict(list)
 
-    for name,value in defs.iteritems():
+    for name,value in defs.items():
         if "properties" in value:
             props = value["properties"]
-            for df in props.values():
+            for df in list(props.values()):
                 if "$ref" in df:
                     def_refs[name].append(df["$ref"][len('#/definitions/'):])
-    order = [(y,x) for x in def_refs.keys() for y in def_refs[x]]
-    ordered_names = ivy.ivy_utils.topological_sort(defs.keys(),order)
+    order = [(y,x) for x in list(def_refs.keys()) for y in def_refs[x]]
+    ordered_names = ivy.ivy_utils.topological_sort(list(defs.keys()),order)
     defs = collections.OrderedDict((x,defs[x]) for x in ordered_names)
                     
     def get_ref_or_type(prop,name,df):
@@ -250,7 +250,7 @@ def main():
 
 
 
-    for name,value in defs.iteritems():
+    for name,value in defs.items():
         if not isinstance(value,dict):
             format_error(inpname,'entry {} not a dictionary'.format(name))
         if "properties" in value:
@@ -261,7 +261,7 @@ def main():
             num_props = len(props)
             if not isinstance(props,dict):
                 format_error(inpname,'properties of entry {} not a dictionary'.format(name))
-            for idx,(prop,df) in enumerate(props.iteritems()):
+            for idx,(prop,df) in enumerate(props.items()):
                 ty = get_ref_or_type(prop,name,df)
                 comment = ' # ' + df["description"] if "description" in df else ''
                 items.append('        {}_ : {}{} {}\n'.format(iname(prop),ty,',' if idx < num_props-1 else '',comment))
@@ -275,13 +275,13 @@ def main():
     paths = spec["paths"]
         
     path_count = 0
-    for path,value in paths.iteritems():
+    for path,value in paths.items():
         path_count = path_count + 1
         if not isinstance(value,dict):
             format_error(inpname,'path entry {} not a dictionary'.format(path))
         out.write("\n# path: {}\n".format(path))
         out.write("object path_{} = {{\n".format(path_count))
-        for opname,op in value.iteritems():
+        for opname,op in value.items():
             if not isinstance(op,dict):
                 format_error(inpname,'op entry {} not a dictionary'.format(opname))
             out.write("\n    action {}".format(iname(opname)))
@@ -317,7 +317,7 @@ def main():
             out.write('\n')
             if "responses" not in op:
                 format_error(inpname,'path {} op {} has no responses field'.format(path,opname))
-            for respname,resp in op["responses"].iteritems():
+            for respname,resp in op["responses"].items():
                 if "schema" not in resp:
                     type = "unit"
                 else:

--- a/doc/examples/rest/trans.py
+++ b/doc/examples/rest/trans.py
@@ -26,13 +26,13 @@ def read_file(name):
 #        exit(1)
 
 def match_path(spath,rpath):
-    print spath
+    print(spath)
     parms = dict()
     if len(spath) != len(rpath):
         return None
     for x,y in zip(spath,rpath):
-        print x
-        print y
+        print(x)
+        print(y)
         if x.startswith('{'):
             parms[x[1:-1]] = y
         elif x != y:
@@ -70,7 +70,7 @@ def main():
             parms[p] = v
         
     matched = False
-    for path,stuff in spec['paths'].iteritems():
+    for path,stuff in spec['paths'].items():
         spath = path[1:].split('/')
         pparms = match_path(spath,rpath)
         if pparms is not None:
@@ -82,7 +82,7 @@ def main():
         sys.stderr.write('cannot match path {}\n'.format(rpath))
         exit(1)
 
-    print list(parms.iteritems())
+    print(list(parms.items()))
     
         
     

--- a/doc/examples/timeout_test_expect.py
+++ b/doc/examples/timeout_test_expect.py
@@ -8,5 +8,5 @@ def run(name,opts,res):
         child.expect('foo.timeout')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/doc/examples/udp_test2_expect.py
+++ b/doc/examples/udp_test2_expect.py
@@ -15,7 +15,7 @@ def run(name,opts,res):
         child[0].expect(r'< foo.recv\(4\)')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False
     finally:
         for idx in range(2):

--- a/doc/examples/udp_test_expect.py
+++ b/doc/examples/udp_test_expect.py
@@ -12,5 +12,5 @@ def run(name,opts,res):
         child.expect(r'foo.recv\(0,3\)')
         return True
     except pexpect.EOF:
-        print child.before
+        print(child.before)
         return False

--- a/ivy/client_server_example.py
+++ b/ivy/client_server_example.py
@@ -18,10 +18,10 @@ c(A0, B0) &
 
 """
 
-from logic import *
-from concept import *
-from concept_alpha import alpha
-from logic_util import *
+from .logic import *
+from .concept import *
+from .concept_alpha import alpha
+from .logic_util import *
 
 client_sort = UninterpretedSort('client')
 server_sort = UninterpretedSort('server')
@@ -72,50 +72,50 @@ concepts.add('edges','c', [X,Y], c(X,Y))
 cd = ConceptDomain(concepts, get_standard_combiners(), get_standard_combinations())
 
 if __name__ == '__main__':
-    print "State:"
-    print state
-    print
+    print("State:")
+    print(state)
+    print()
 
-    print "Skolemized State:"
-    print state_sk
-    print
+    print("Skolemized State:")
+    print(state_sk)
+    print()
 
 
-    print "Concept Domain:"
+    print("Concept Domain:")
     cd.output()
-    print
+    print()
 
-    print "Facts:"
+    print("Facts:")
     for tag, formula in cd.get_facts():
-        print '   ', tag, formula
-    print
+        print('   ', tag, formula)
+    print()
 
-    print "alpha:"
+    print("alpha:")
     a = alpha(cd, state_sk)
     for tag, value in a:
         if value:
-            print '   ', tag
-    print
+            print('   ', tag)
+    print()
 
-    print "\n=== Splitting c_server on c_s ===\n"
+    print("\n=== Splitting c_server on c_s ===\n")
 
     cd.split('server', 's')
 
-    print "Concept Domain:"
+    print("Concept Domain:")
     cd.output()
-    print
+    print()
 
-    print "Facts:"
+    print("Facts:")
     for tag, formula in cd.get_facts():
-        print '   ', tag, formula
-    print
+        print('   ', tag, formula)
+    print()
 
-    print "alpha:"
+    print("alpha:")
     a = alpha(cd, state_sk)
     for tag, value in a:
         if value:
-            print '   ', tag
-    print
+            print('   ', tag)
+    print()
 
     from concept_render import render_concept_graph
 
@@ -125,7 +125,7 @@ if __name__ == '__main__':
         cd.concepts['edges'],
         cd.concepts['node_labels'],
     )
-    print "graph elements:"
+    print("graph elements:")
     for x in elements:
-        print '   ', x, ','
-    print
+        print('   ', x, ',')
+    print()

--- a/ivy/concept_alpha.py
+++ b/ivy/concept_alpha.py
@@ -5,10 +5,10 @@
 """
 
 # from z3_utils import z3_implies
-import ivy_solver as slvr
-from logic import Or, Not
+from . import ivy_solver as slvr
+from .logic import Or, Not
 import time
-import ivy_utils as iu
+from . import ivy_utils as iu
 
 def alpha(concept_domain, state, cache=None, projection=None):
     """
@@ -56,14 +56,14 @@ def alpha(concept_domain, state, cache=None, projection=None):
 
 if __name__ == '__main__':
     from collections import ConceptDict
-    from logic import (Var, Const, Apply, Eq, Not, And, Or, Implies,
+    from .logic import (Var, Const, Apply, Eq, Not, And, Or, Implies,
                        ForAll, Exists)
-    from logic import UninterpretedSort, FunctionSort, first_order_sort, Boolean
-    from logic_util import free_variables, substitute, substitute_apply
-    from concept import Concept, ConceptCombiner, ConceptDomain
+    from .logic import UninterpretedSort, FunctionSort, first_order_sort, Boolean
+    from .logic_util import free_variables, substitute, substitute_apply
+    from .concept import Concept, ConceptCombiner, ConceptDomain
 
     def test(st):
-        print st, "=", eval(st)
+        print(st, "=", eval(st))
 
     S = UninterpretedSort('S')
     UnaryRelation = FunctionSort(S, Boolean)
@@ -127,10 +127,10 @@ if __name__ == '__main__':
     )
 
     facts = cd.get_facts()
-    print "facts = ["
+    print("facts = [")
     for tag, formula in facts:
-        print '   ', tag, formula, ','
-    print "]\n"
+        print('   ', tag, formula, ',')
+    print("]\n")
 
     state = And(
         ForAll([X,Y,Z], And(
@@ -146,7 +146,7 @@ if __name__ == '__main__':
     )
 
     abstract_value = alpha(cd, state)
-    print "abstract_value = ["
+    print("abstract_value = [")
     for tag, value in abstract_value:
-        print '   ', tag, value, ','
-    print "]\n"
+        print('   ', tag, value, ',')
+    print("]\n")

--- a/ivy/concept_interactive_session.py
+++ b/ivy/concept_interactive_session.py
@@ -7,14 +7,14 @@
 from itertools import product
 import copy
 
-from concept_alpha import alpha
-from logic import Var, Const, And, Not, ForAll, Eq, TopSort, SortError
-from logic_util import (free_variables, used_constants,
+from .concept_alpha import alpha
+from .logic import Var, Const, And, Not, ForAll, Eq, TopSort, SortError
+from .logic_util import (free_variables, used_constants,
                         is_tautology_equality, normalize_quantifiers, substitute)
-from z3_utils import z3_implies
-from concept import Concept
+from .z3_utils import z3_implies
+from .concept import Concept
 
-from ivy_utils import constant_name_generator, dbg
+from .ivy_utils import constant_name_generator, dbg
 
 
 def _normalize_facts(facts):
@@ -76,7 +76,7 @@ class ConceptInteractiveSession(object):
 
     def _fresh_const_name(self, extra=frozenset()):
         contents = ([self._to_formula()] +
-                    [c.formula for n,c in self.domain.concepts.iteritems() if isinstance(c,Concept)])
+                    [c.formula for n,c in self.domain.concepts.items() if isinstance(c,Concept)])
         used = frozenset(c.name for c in (
             used_constants(*contents) | extra
         ))

--- a/ivy/cy_elements.py
+++ b/ivy/cy_elements.py
@@ -52,7 +52,7 @@ class CyElements(object):
         assert self.elements is not None, "This object us not reusable"
         if label is None:
             label = str(obj)
-        if not isinstance(classes, basestring):
+        if not isinstance(classes, str):
             classes = ' '.join(str(x) for x in classes)
         nid = 'n{}'.format(len(self.node_id))
         assert obj not in self.node_id, "obj must be unique"
@@ -86,7 +86,7 @@ class CyElements(object):
         assert self.elements is not None, "This object us not reusable"
         if label is None:
             label = str(obj)
-        if not isinstance(classes, basestring):
+        if not isinstance(classes, str):
             classes = ' '.join(str(x) for x in classes)
         eid = 'e{}'.format(len(self.edge_id))
         assert (obj, source_obj, target_obj) not in self.edge_id
@@ -115,7 +115,7 @@ class CyElements(object):
         Add a node. See class docstring for details.
         """
         assert self.elements is not None, "This object us not reusable"
-        if not isinstance(classes, basestring):
+        if not isinstance(classes, str):
             classes = ' '.join(str(x) for x in classes)
         sid = 's{}'.format(len(self.shape_id))
         self.shape_id[obj] = sid

--- a/ivy/cy_render.py
+++ b/ivy/cy_render.py
@@ -12,8 +12,8 @@ cytoscape.js's JSON format.
 from itertools import product
 from collections import defaultdict
 
-from tactics_api import refuted_goal
-from widget_cy_graph import CyElements
+from .tactics_api import refuted_goal
+from .widget_cy_graph import CyElements
 
 
 def get_shape(concept_name):
@@ -51,14 +51,14 @@ def get_transitive_reduction(widget, a, edges):
 
 _label_prefix = {
     'node_necessarily': '',
-    'node_necessarily_not': u'\u00AC', # negation sign
+    'node_necessarily_not': '\u00AC', # negation sign
     'node_maybe': '?',
 }
 
 _label_prefix_equality = {
     'node_necessarily': '=',
-    'node_necessarily_not': u'\u2260', # not equal sign
-    'node_maybe': u'\u225F', # =? sign
+    'node_necessarily_not': '\u2260', # not equal sign
+    'node_maybe': '\u225F', # =? sign
 }
 
 def render_concept_graph(widget):
@@ -76,7 +76,7 @@ def render_concept_graph(widget):
 
     # treat custom_edge_info and custom_node_label
     custom = set()
-    for tag in a.keys():
+    for tag in list(a.keys()):
         if tag[0].startswith('custom_'):
             not_custom_tag = (tag[0][len('custom_'):],) + tag[1:]
             a[not_custom_tag] = a[tag]

--- a/ivy/dot_layout.py
+++ b/ivy/dot_layout.py
@@ -7,20 +7,20 @@ Use DOT to layout a graph for cytoscape.js
 TODO: add support for middle points in edges
 """
 
-from __future__ import division
+
 
 from collections import deque, defaultdict
 
 import platform
 if True or platform.system() == 'Windows':
-    from ivy_graphviz import AGraph
+    from .ivy_graphviz import AGraph
 else:
     from pygraphviz import AGraph
 
 
-from ivy_utils import topological_sort
+from .ivy_utils import topological_sort
 
-import ivy_utils as iu
+from . import ivy_utils as iu
 
 # import pygraphviz
 
@@ -130,7 +130,7 @@ def _to_coord_list(st):
     """ create a sequence of positions from a dot-generated string """
     nums = st.split(',')
     pairs = [','.join((nums[2*i],nums[2*i+1])) for i in range(len(nums)//2)]
-    return map(_to_position,pairs)
+    return list(map(_to_position,pairs))
 
 
 def dot_layout(cy_elements,edge_labels=False,subgraph_boxes=False,node_gt=None):

--- a/ivy/interrupt_context.py
+++ b/ivy/interrupt_context.py
@@ -25,8 +25,8 @@ if __name__ == '__main__':
     with InterruptContext() as c:
         while True:
             i += 1
-            print i
+            print(i)
             sleep(3)
-            print c.interrupted
+            print(c.interrupted)
             c.interrupted = False
-            print
+            print()

--- a/ivy/iupdr.py
+++ b/ivy/iupdr.py
@@ -12,13 +12,13 @@ import IPython.html.widgets as widgets
 
 import z3
 
-import tactics_api as ta
-import tactics as t
-import ivy_transrel
-from ivy_logic_utils import negate_clauses, Clauses, and_clauses, simplify_clauses
-from ui_extensions_api import interaction, ShowModal, InteractionError, UserSelectMultiple
-import ivy_solver
-from ivy_solver import clauses_to_z3
+from . import tactics_api as ta
+from . import tactics as t
+from . import ivy_transrel
+from .ivy_logic_utils import negate_clauses, Clauses, and_clauses, simplify_clauses
+from .ui_extensions_api import interaction, ShowModal, InteractionError, UserSelectMultiple
+from . import ivy_solver
+from .ivy_solver import clauses_to_z3
 
 class UserSelectCore(ShowModal):
     """
@@ -139,7 +139,7 @@ def interactive_updr():
 
             if current_goal.node == init_frame:
                 # no invariant
-                print "No Invariant!"
+                print("No Invariant!")
                 # return False
 
             dg = ta.get_diagram(current_goal, False)
@@ -150,7 +150,7 @@ def interactive_updr():
                 options=options,
                 title="Generalize Diagram",
                 prompt="Choose which literals to take as the refutation goal",
-                default=options.values()
+                default=list(options.values())
             ))
             assert user_selection is not None
             ug = ta.goal_at_arg_node(Clauses(list(user_selection)), current_goal.node)

--- a/ivy/ivy.py
+++ b/ivy/ivy.py
@@ -3,9 +3,9 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-from ivy_init import ivy_init 
-import ivy_module
-from tk_ui import ui_main_loop
+from .ivy_init import ivy_init 
+from . import ivy_module
+from .tk_ui import ui_main_loop
 
 def main():
     import signal

--- a/ivy/ivy2.py
+++ b/ivy/ivy2.py
@@ -87,10 +87,10 @@ if __name__ == '__main__':
     # if X.ipynb exists, open it, otherwise create a new X.ivy.ipynb
     notebook_filename = ivy_filename[:-4] + '.ipynb'
     if os.path.isfile(notebook_filename):
-        print "Opening existing notebook: {}".format(notebook_filename)
+        print("Opening existing notebook: {}".format(notebook_filename))
     else:
         notebook_filename = ivy_filename + '.ipynb'
-        print "Creating new notebook: {}".format(notebook_filename)
+        print("Creating new notebook: {}".format(notebook_filename))
         open(notebook_filename, 'w').write(notebook_source)
 
     d = dirname(__file__)

--- a/ivy/ivy_actions.py
+++ b/ivy/ivy_actions.py
@@ -368,7 +368,7 @@ def destr_asgn_val(lhs,fmlas):
     vs = sym_placeholders(n)
     dlhs = n(*([lval] + vs[1:]))
     drhs = n(*([mut] + vs[1:]))
-    eqs = [eq_atom(v,a) for (v,a) in zip(vs,lhs.args)[1:] if not isinstance(a,Variable)]
+    eqs = [eq_atom(v,a) for (v,a) in list(zip(vs,lhs.args))[1:] if not isinstance(a,Variable)]
     if eqs:
         fmlas.append(Or(And(*eqs),equiv_ast(dlhs,drhs)))
     for destr in ivy_module.module.sort_destructors[mut.sort.name]:
@@ -455,7 +455,7 @@ class AssignAction(Action):
             vs = sym_placeholders(n)
             dlhs = n(*([nondet(*mut.args)] + vs[1:]))
             drhs = n(*([mut] + vs[1:]))
-            eqs = [eq_atom(v,a) for (v,a) in zip(vs,lhs.args)[1:] if not isinstance(a,Variable)]
+            eqs = [eq_atom(v,a) for (v,a) in list(zip(vs,lhs.args))[1:] if not isinstance(a,Variable)]
             if eqs:
                 fmlas.append(Or(And(*eqs),equiv_ast(dlhs,drhs)))
             for destr in ivy_module.module.sort_destructors[mut.sort.name]:

--- a/ivy/ivy_actions.py
+++ b/ivy/ivy_actions.py
@@ -1,20 +1,20 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_logic import Variable,Constant,Atom,Literal,App,sig,Iff,And,Or,Not,Implies,EnumeratedSort,Ite,Definition, is_atom, equals, Equals, Symbol,ast_match_lists, is_in_logic, Exists, RelationSort, is_boolean, is_app, is_eq, pto, close_formula,symbol_is_polymorphic,is_interpreted_symbol 
+from .ivy_logic import Variable,Constant,Atom,Literal,App,sig,Iff,And,Or,Not,Implies,EnumeratedSort,Ite,Definition, is_atom, equals, Equals, Symbol,ast_match_lists, is_in_logic, Exists, RelationSort, is_boolean, is_app, is_eq, pto, close_formula,symbol_is_polymorphic,is_interpreted_symbol 
 
-from ivy_logic_utils import to_clauses, formula_to_clauses, substitute_constants_clause,\
+from .ivy_logic_utils import to_clauses, formula_to_clauses, substitute_constants_clause,\
     substitute_clause, substitute_ast, used_symbols_clauses, used_symbols_ast, rename_clauses, subst_both_clauses,\
     variables_distinct_ast, is_individual_ast, variables_distinct_list_ast, sym_placeholders, sym_inst, apps_ast,\
     eq_atom, eq_lit, eqs_ast, TseitinContext, formula_to_clauses_tseitin,\
     used_symbols_asts, symbols_asts, has_enumerated_sort, false_clauses, true_clauses, or_clauses, dual_formula, Clauses, and_clauses, substitute_constants_ast, rename_ast, bool_const, used_variables_ast, unfold_definitions_clauses, skolemize_formula
-from ivy_transrel import state_to_action,new, compose_updates, condition_update_on_fmla, hide, join_action, ite_action, \
+from .ivy_transrel import state_to_action,new, compose_updates, condition_update_on_fmla, hide, join_action, ite_action, \
     subst_action, null_update, exist_quant, hide_state, hide_state_map, constrain_state, bind_olds_action, old
-from ivy_utils import unzip_append, IvyError, IvyUndefined, distinct_obj_renaming, dbg
-import ivy_ast
-from ivy_ast import AST, compose_atoms, MixinAfterDef
-import ivy_module
-import ivy_utils as iu
+from .ivy_utils import unzip_append, IvyError, IvyUndefined, distinct_obj_renaming, dbg
+from . import ivy_ast
+from .ivy_ast import AST, compose_atoms, MixinAfterDef
+from . import ivy_module
+from . import ivy_utils as iu
 
 def p_c_a(s):
     a = s.split(':')
@@ -421,7 +421,7 @@ class AssignAction(Action):
 
         lhs_vars = used_variables_ast(lhs)
         if any(v not in lhs_vars for v in used_variables_ast(rhs)):
-            print self
+            print(self)
             raise IvyError(self,"multiply assigned: {}".format(lhs.rep))
 
         type_check(domain,rhs)
@@ -1096,7 +1096,7 @@ class CallAction(Action):
 #        subst = dict(zip(v.formal_params+v.formal_returns, formal_params+formal_returns))
         vocab = list(symbols_asts(actual_params+actual_returns))
         subst = distinct_obj_renaming(v.formal_params+v.formal_returns,vocab)
-        for s,t in list(subst.iteritems()):
+        for s,t in list(subst.items()):
             subst[old(s)] = old(t)
 #        print "apply_actuals: subst: {}".format(subst)
         formal_params = [subst[s] for s in  v.formal_params] # rename to prevent capture
@@ -1108,17 +1108,17 @@ class CallAction(Action):
         if len(formal_params) != len(actual_params):
             raise IvyError(self,"wrong number of input parameters");
         if len(formal_returns) != len(actual_returns):
-            print self
+            print(self)
             raise IvyError(self,"wrong number of output parameters");
         for x,y in zip(formal_params,actual_params):
             if x.sort != y.sort and not domain.is_variant(x.sort,y.sort):
                 raise IvyError(self,"value for input parameter {} has wrong sort".format(x))
         for x,y in zip(formal_returns,actual_returns):
             if x.sort != y.sort and not domain.is_variant(y.sort,x.sort):
-                print y
-                print y.sort
-                print x.sort
-                print self
+                print(y)
+                print(y.sort)
+                print(x.sort)
+                print(self)
                 raise IvyError(self,"value for output parameter {} has wrong sort".format(x))
         input_asgns = [AssignAction(x,y) for x,y in zip(formal_params,actual_params)]
         output_asgns = [AssignAction(y,x) for x,y in zip(formal_returns,actual_returns)]
@@ -1205,11 +1205,11 @@ def concat_actions(*actions):
 
 def apply_mixin(decl,action1,action2):
     if not hasattr(action1,'lineno'):
-        print action1
-        print type(action1)
+        print(action1)
+        print(type(action1))
     assert hasattr(action1,'lineno')
     if not hasattr(action2,'lineno'):
-        print action2
+        print(action2)
     assert  hasattr(action2,'lineno')
     name1,name2 = (a.relname for a in decl.args)
     if len(action1.formal_params) != len(action2.formal_params):
@@ -1220,7 +1220,7 @@ def apply_mixin(decl,action1,action2):
     for x,y in zip(formals1,formals2):
         if x.sort != y.sort:
             raise IvyError(decl,"parameter {} of mixin {} has wrong sort".format(str(x),name1))
-    subst = dict(zip(formals1,formals2))
+    subst = dict(list(zip(formals1,formals2)))
     action1_renamed = substitute_constants_ast(action1,subst)
 #    print "action1_renamed: {}".format(action1_renamed)
     if isinstance(decl,MixinAfterDef):
@@ -1343,7 +1343,7 @@ class RenameAnnotation(Annotation):
         self.map = map.copy()
         self.arg = arg
     def __str__(self):
-        return 'Rename({},'.format(str(self.arg)) + '{' + ','.join('{}:{}'.format(x,y) for x,y in self.map.iteritems()) + '})'
+        return 'Rename({},'.format(str(self.arg)) + '{' + ','.join('{}:{}'.format(x,y) for x,y in self.map.items()) + '})'
 
 class IteAnnotation(Annotation):
     def __init__(self,cond,thenb,elseb):
@@ -1397,12 +1397,12 @@ class IgnoreAction(object):
 def match_annotation(action,annot,handler):
     def recur(action,annot,env,pos=None):
         def show_me():
-            print 'lineno: {} annot: {} pos: {}'.format(action.lineno if hasattr(action,'lineno') else None,annot,pos)
+            print('lineno: {} annot: {} pos: {}'.format(action.lineno if hasattr(action,'lineno') else None,annot,pos))
 
         try:
             if isinstance(annot,RenameAnnotation):
                 save = dict()
-                for x,y in annot.map.iteritems():
+                for x,y in annot.map.items():
                     if x in env:
                         save[x] = env[x]
                     env[x] = env.get(y,y)
@@ -1441,7 +1441,7 @@ def match_annotation(action,annot,handler):
                 try:
                     cond = handler.eval(rncond)
                 except KeyError:
-                    print '{}skipping conditional'.format(action.lineno)
+                    print('{}skipping conditional'.format(action.lineno))
                     iu.dbg('str_map(env)')
                     iu.dbg('env.get(annot.cond,annot.cond)')
                     return
@@ -1463,7 +1463,7 @@ def match_annotation(action,annot,handler):
                 assert isinstance(annot,IteAnnotation)
                 annots = unite_annot(annot)
                 assert len(annots) == len(action.args)
-                for act,(cond,ann) in reversed(zip(action.args,annots)):
+                for act,(cond,ann) in reversed(list(zip(action.args,annots))):
                     if handler.eval(cond):
                         if isinstance(action,EnvAction) and not hasattr(action,'label'):
                             callact = act

--- a/ivy/ivy_alpha.py
+++ b/ivy/ivy_alpha.py
@@ -6,11 +6,11 @@ import itertools
 from collections import defaultdict
 import z3
 
-from ivy_logic_utils import to_literal, false_clauses, Clauses
-from ivy_solver import *
-from ivy_logic_utils import *
-from ivy_concept_space import *
-from ivy_utils import Parameter
+from .ivy_logic_utils import to_literal, false_clauses, Clauses
+from .ivy_solver import *
+from .ivy_logic_utils import *
+from .ivy_concept_space import *
+from .ivy_utils import Parameter
 
 test_bottom = True
 
@@ -44,26 +44,26 @@ class ProgressiveDomain(object):
         id = self.cube_id(cube)
         if id not in self.inhabited_cubes:
             if log:
-                print "inhabited: %s" % cube
+                print("inhabited: %s" % cube)
 #            print "witness: %s" % witness
             self.inhabited_cubes[id] = truth
 
     def model_check(self):
         return
         if log:
-            print "model_check {"
+            print("model_check {")
 #        print "  model: %s" % get_model(self.solver)
         ra = RelAlg3(self.solver,self.new_sym,self)
         memo = dict()
         for atom,cs in self.concept_spaces:
-            print "model check concept space: %s" % atom
+            print("model check concept space: %s" % atom)
             insts = cs.eval(memo,ra)
             memo[atom.relname] = ([t.rep for t in atom.args],insts)
             for cube,tab in insts:
                 self.inhabited_cube(cube)
 
         if log:
-            print "} model_check"
+            print("} model_check")
 
     def inhabited_lit(self,lit):
         self.inhabited_cube([lit])
@@ -77,14 +77,14 @@ class ProgressiveDomain(object):
     def test_cube(self,cube):
         canon_cube = canonize_clause(cube)
         if log:
-            print "cube: {}".format([str(c) for c in canon_cube])
+            print("cube: {}".format([str(c) for c in canon_cube]))
         my_id = self.cube_id(canon_cube)
         if my_id in self.inhabited_cubes:
             if log:
-                print "cached: %s" % [str(c) for c in cube]
+                print("cached: %s" % [str(c) for c in cube])
             return self.inhabited_cubes[my_id]
         if log:
-            print "test: %s" % [str(c) for c in cube]
+            print("test: %s" % [str(c) for c in cube])
         cube = rename_clause(cube,self.new_sym)
         vs = used_variables_clause(cube)
         # TODO: these constants need to have right sorts
@@ -98,7 +98,7 @@ class ProgressiveDomain(object):
         else:
             self.inferred.append([~lit for lit in cube])
             if log:
-                print "uninhabited: %s" % [str(c) for c in canon_cube]
+                print("uninhabited: %s" % [str(c) for c in canon_cube])
             self.inhabited_cubes[my_id] = False
         return res
 
@@ -110,12 +110,12 @@ class ProgressiveDomain(object):
         self.z3_cubes = []
         self.memo = dict()
         if log:
-            print "concrete state: %s" % theory
-            print "background: %s" % background_theory
+            print("concrete state: %s" % theory)
+            print("background: %s" % background_theory)
         add_clauses(self.solver, and_clauses(theory,background_theory))
         self.unsat = test_bottom and self.solver.check() == z3.unsat
         if self.unsat:
-            print "core: %s" % unsat_core(and_clauses(theory,background_theory),true_clauses())
+            print("core: %s" % unsat_core(and_clauses(theory,background_theory),true_clauses()))
         
     def post_step(self,concept_spaces):
         if self.unsat:
@@ -124,14 +124,14 @@ class ProgressiveDomain(object):
 #        print "cs: {}".format(concept_spaces)
         for atom,cs in concept_spaces:
             if log:
-                print "concept space: %s" % atom
+                print("concept space: %s" % atom)
             concepts = cs.enumerate(self.memo,self.test_cube)
             if log:
-                print "result: {}".format([str(c) for c in concepts])
+                print("result: {}".format([str(c) for c in concepts]))
             self.memo[atom.relname] = ([t.rep for t in atom.args], concepts)
         res = self.inferred
         if log:
-            print "inferred: {}".format([[str(c) for c in cls] for cls in res])
+            print("inferred: {}".format([[str(c) for c in cls] for cls in res]))
         del self.inferred
         return Clauses(res)
 
@@ -257,7 +257,7 @@ class RelAlg2(object):
                                  if not isinstance(x,Variable)])
             cubes = [cube] if is_sat(self.temp_solver,cube) else []
             if not cubes:
-                print "unsat: %s" % cube
+                print("unsat: %s" % cube)
                 exit(0)
         else:
             new_lit = rename_lit(lit,self.new_sym)
@@ -279,7 +279,7 @@ class RelAlg2(object):
 #        print "prod: %s * %s = %s" % (x,y,cubes)
         return cubes
     def subst(self,tab,subst):
-        subs = [(term_to_z3(Constant(x)),term_to_z3(y)) for x,y in subst.iteritems()]
+        subs = [(term_to_z3(Constant(x)),term_to_z3(y)) for x,y in subst.items()]
 #        print subs
  #       print all([isinstance(p, tuple) and z3.is_expr(p[0]) and z3.is_expr(p[1]) and p[0].sort().eq(p[1].sort()) for p in subs])
         res = [z3.substitute(x,*subs) for x in tab]
@@ -290,7 +290,7 @@ class RelAlg2(object):
                 
 class RelAlg3(RelAlg2):
     def prim(self,lit):
-        print "prim: %s" % lit
+        print("prim: %s" % lit)
         z3lit = literal_to_z3(lit)
 #        print z3lit
         id = get_id(z3lit)
@@ -316,7 +316,7 @@ if __name__ == "__main__":
     d.add_concept_space(to_atom("s3(X,Y)"),to_concept_space("(~p(X,c) * =(X,a))"))
     theory = to_clauses("[[p(a,b)],[~p(b,a)],[p(a,c)],[~p(a,a)]]")
     cons = d.post(theory,[],dict(),[])
-    print cons
+    print(cons)
     # solver = new_solver()
     # add_clauses(solver,to_clauses("[[p(a,b)],[~p(b,a)],[p(a,c)],[~p(a,a)]]"))
     # res = check_cube(solver,[])

--- a/ivy/ivy_art.py
+++ b/ivy/ivy_art.py
@@ -1,16 +1,16 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-import ivy_actions
-from ivy_interp import *
-import ivy_utils as iu
-import ivy_module as im
-from cy_elements import CyElements
+from . import ivy_actions
+from .ivy_interp import *
+from . import ivy_utils as iu
+from . import ivy_module as im
+from .cy_elements import CyElements
 from string import *
 import copy
 import functools
 import pickle
-import ivy_actions
+from . import ivy_actions
 
 
 ################################################################################
@@ -54,7 +54,7 @@ class AC(ivy_actions.ActionContext):
 class Counterexample(object):
     def __init__(self,clauses,state,conc,msg):
         self.clauses, self.state, self.msg, self.conc = clauses, state, msg, conc
-    def __nonzero__(self):
+    def __bool__(self):
         return False
 
 ########################################
@@ -124,7 +124,7 @@ class AnalysisGraph(object):
             if self.predicates:
                 if not im.module.init_cond.is_true():
                     raise IvyError(None,"init and state declarations are not compatible");
-                for n,p in self.predicates.iteritems():
+                for n,p in self.predicates.items():
                     s = eval_state_facts(p)
                     if s is not None:
                         s.label = n
@@ -134,7 +134,7 @@ class AnalysisGraph(object):
 
     def state_actions(self,state):
         if hasattr(state,'label') and state.label != None:
-            return [state_equation(post,expr) for post,e in self.predicates.iteritems() for expr in eval_state_actions(e,state)]
+            return [state_equation(post,expr) for post,e in self.predicates.items() for expr in eval_state_actions(e,state)]
         return [state_equation(None,action_app(a,state)) for a in self.actions if a in self.public_actions]
 
     def do_state_action(self,equation,abstractor):
@@ -172,7 +172,7 @@ class AnalysisGraph(object):
             if covered.id == poststate.id:
                 self.covering.remove(c)
                 self.cover(poststate,covering)
-        print "recalculated state %s: %s" % (poststate.id,poststate.clauses)
+        print("recalculated state %s: %s" % (poststate.id,poststate.clauses))
 
     def recalculate_state(self,state,abstractor=None):
         if hasattr(state,'pred') and state.pred:
@@ -212,16 +212,16 @@ class AnalysisGraph(object):
             state2 = self.states[len(self.states)-1]
         joined_state = self.join_states(state1,state2,abstractor)
         self.add(joined_state,state_join(state1,state2))
-        print "joined state: %s" % joined_state.clauses
+        print("joined state: %s" % joined_state.clauses)
         return joined_state
 
     def cover(self,covered_node,covering_node):
         if covered_node.domain.order(covered_node,covering_node):
-            print "Covering succeeded: %s %s" % (covered_node.id, covering_node.id)
+            print("Covering succeeded: %s %s" % (covered_node.id, covering_node.id))
             self.covering.append((covered_node,covering_node))
             return True
         else:
-            print "Covering failed"
+            print("Covering failed")
             return False
 
     def is_covered(self,node):
@@ -230,18 +230,18 @@ class AnalysisGraph(object):
     def unreachable(self,covered_node):
         covering_node = State(covered_node.domain,[[]])
         if covered_node.domain.order(covered_node,covering_node):
-            print "Unreachable: %s" % covered_node.id
+            print("Unreachable: %s" % covered_node.id)
             covered_node.clauses = [[]]
             return True
         else:
-            print "Unreachability check failed"
+            print("Unreachability check failed")
             return False
 
     def show_core(self,clause_str,state = None):
         clause = to_clause(clause_str)
         if state == None:
             state = self.states[len(self.states)-1]
-        print state.domain.get_core(state,clause)
+        print(state.domain.get_core(state,clause))
 
     def add(self,state,expr=None):
         state.id = len(self.states)
@@ -429,8 +429,8 @@ class AnalysisGraph(object):
         for state in self.uncovered_states:
             if hasattr(state,'label'):
                 fpc[state.label].append(state)
-        print "fpc = {}".format(fpc)
-        return defaultdict(bottom_state,((x,join(*y)) for x,y in fpc.iteritems()))
+        print("fpc = {}".format(fpc))
+        return defaultdict(bottom_state,((x,join(*y)) for x,y in fpc.items()))
 
     def state_extensions(self,state, join = state_join):
         sas = self.state_actions(state)

--- a/ivy/ivy_ast.py
+++ b/ivy/ivy_ast.py
@@ -5,9 +5,9 @@
 Ivy abstract syntax trees.
 """
 
-from ivy_utils import flatten, gen_to_set, UniqueRenamer, compose_names, split_name, IvyError, base_name
-import ivy_utils as iu
-import ivy_logic
+from .ivy_utils import flatten, gen_to_set, UniqueRenamer, compose_names, split_name, IvyError, base_name
+from . import ivy_utils as iu
+from . import ivy_logic
 import re
 
 class AST(object):
@@ -1263,7 +1263,7 @@ class ActionDef(Definition):
         return self.args[1].iter_internal_defines()
     def clone(self,args):
         if not hasattr(self.args[1],'lineno'):
-            print 'no lineno!!!!!: {}'.format(self)
+            print('no lineno!!!!!: {}'.format(self))
         res = ActionDef(args[0],args[1])
         res.formal_params = self.formal_params
         res.formal_returns = self.formal_returns
@@ -1417,7 +1417,7 @@ def subst_subscripts_comp(s,subst):
     try:
         res =  pref + ''.join(('[' + str_subst_str(x[1:-1],subst) + ']' if x.startswith('[') else x) for x in g[1:])
     except:
-        print "s: {} subst : {}".format(s,subst)
+        print("s: {} subst : {}".format(s,subst))
 #    print "res: {}".format(res)
     return res
 
@@ -1552,7 +1552,7 @@ def ast_rewrite(x,rewrite):
         return x
     if hasattr(x,'args'):
         return x.clone(ast_rewrite(x.args,rewrite)) # yikes!
-    print "wtf: {} {}".format(x,type(x))
+    print("wtf: {} {}".format(x,type(x)))
     assert False
 
 def subst_prefix_atoms_ast(ast,subst,pref,to_pref,static=None):

--- a/ivy/ivy_bmc.py
+++ b/ivy/ivy_bmc.py
@@ -2,19 +2,19 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_module as im
-import ivy_actions as ia
-import logic as lg
-import ivy_logic as il
-import ivy_transrel as tr
-import ivy_logic_utils as ilu
-import ivy_utils as iu
-import ivy_art as art
-import ivy_interp as itp
-import ivy_theory as thy
-import ivy_ast
-import ivy_proof
-import ivy_trace
+from . import ivy_module as im
+from . import ivy_actions as ia
+from . import logic as lg
+from . import ivy_logic as il
+from . import ivy_transrel as tr
+from . import ivy_logic_utils as ilu
+from . import ivy_utils as iu
+from . import ivy_art as art
+from . import ivy_interp as itp
+from . import ivy_theory as thy
+from . import ivy_ast
+from . import ivy_proof
+from . import ivy_trace
 
 def check_isolate(n_steps):
     
@@ -23,7 +23,7 @@ def check_isolate(n_steps):
     conjectures = im.module.conjs
     conj = ilu.and_clauses(*conjectures)
 
-    used_names = frozenset(x.name for x in il.sig.symbols.values())
+    used_names = frozenset(x.name for x in list(il.sig.symbols.values()))
     def witness(v):
         c = lg.Const('@' + v.name, v.sort)
         assert c.name not in used_names
@@ -40,12 +40,12 @@ def check_isolate(n_steps):
         post = ag.execute(init_action, None, None, 'initialize')
 
     for n in range(n_steps + 1):
-        print 'Checking invariants at depth {}...'.format(n)
+        print('Checking invariants at depth {}...'.format(n))
         res = ivy_trace.check_final_cond(ag,post,clauses,[],True)
         if res is not None:
-            print 'BMC with bound {} found a counter-example...'.format(n)
-            print
-            print res
+            print('BMC with bound {} found a counter-example...'.format(n))
+            print()
+            print(res)
             exit(0)
         post = ag.execute(step_action)
             

--- a/ivy/ivy_check.py
+++ b/ivy/ivy_check.py
@@ -1,32 +1,32 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-import ivy_init
-import ivy_interp as itp
-import ivy_actions as act
-import ivy_utils as utl
-import ivy_logic_utils as lut
-import ivy_logic as lg
-import ivy_utils as iu
-import ivy_module as im
-import ivy_alpha
-import ivy_art
-import ivy_interp
-import ivy_compiler
-import ivy_isolate
-import ivy_ast
-import ivy_theory as ith
-import ivy_transrel as itr
-import ivy_solver as islv
-import ivy_fragment as ifc
-import ivy_proof
-import ivy_trace
-import ivy_temporal as itmp
-import ivy_printer
-import ivy_l2s
-import ivy_mc
-import ivy_bmc
-import ivy_tactics
+from . import ivy_init
+from . import ivy_interp as itp
+from . import ivy_actions as act
+from . import ivy_utils as utl
+from . import ivy_logic_utils as lut
+from . import ivy_logic as lg
+from . import ivy_utils as iu
+from . import ivy_module as im
+from . import ivy_alpha
+from . import ivy_art
+from . import ivy_interp
+from . import ivy_compiler
+from . import ivy_isolate
+from . import ivy_ast
+from . import ivy_theory as ith
+from . import ivy_transrel as itr
+from . import ivy_solver as islv
+from . import ivy_fragment as ifc
+from . import ivy_proof
+from . import ivy_trace
+from . import ivy_temporal as itmp
+from . import ivy_printer
+from . import ivy_l2s
+from . import ivy_mc
+from . import ivy_bmc
+from . import ivy_tactics
 
 import sys
 from collections import defaultdict
@@ -41,7 +41,7 @@ opt_separate = iu.BooleanParameter("separate",None)
 
 def display_cex(msg,ag):
     if diagnose.get():
-        import tk_ui as ui
+        from . import tk_ui as ui
         iu.set_parameters({'mode':'induction'})
         ui.ui_main_loop(ag)
         exit(1)
@@ -50,8 +50,8 @@ def display_cex(msg,ag):
 def check_properties():
     if itp.false_properties():
         if diagnose.get():
-            print "Some properties failed."
-            import tk_ui as ui
+            print("Some properties failed.")
+            from . import tk_ui as ui
             iu.set_parameters({'mode':'induction'})
             gui = ui.new_ui()
             gui.tk.update_idletasks() # so that dialog is on top of main window
@@ -72,7 +72,7 @@ def show_counterexample(ag,state,bmc_res):
     gui_art(other_art)
 
 def gui_art(other_art):
-    import tk_ui as ui
+    from . import tk_ui as ui
 #    iu.set_parameters({'mode':'induction'})
     iu.set_parameters({'ui':'cti'})
     gui = ui.new_ui()
@@ -86,8 +86,8 @@ def check_conjectures(kind,msg,ag,state):
     failed = itp.undecided_conjectures(state)
     if failed:
         if diagnose.get():
-            print "{} failed.".format(kind)
-            import tk_ui as ui
+            print("{} failed.".format(kind))
+            from . import tk_ui as ui
             iu.set_parameters({'mode':'induction'})
             gui = ui.new_ui()
             agui = gui.add(ag)
@@ -112,8 +112,8 @@ def check_temporals():
     pc = ivy_proof.ProofChecker(mod.labeled_axioms+mod.assumed_invariants,mod.definitions,mod.schemata)
     for prop in props:
         if prop.temporal:
-            print '\n    The following temporal property is being proved:\n'
-            print pretty_lf(prop)
+            print('\n    The following temporal property is being proved:\n')
+            print(pretty_lf(prop))
             if prop.temporal:
                 proof = pmap.get(prop.id,None)
                 model = itmp.normal_program_from_module(im.module)
@@ -131,12 +131,12 @@ def check_temporals():
 
 
 def usage():
-    print "usage: \n  {} file.ivy".format(sys.argv[0])
+    print("usage: \n  {} file.ivy".format(sys.argv[0]))
     sys.exit(1)
 
 def find_assertions(action_name=None):
     res = []
-    actions = act.call_set(action_name,im.module.actions) if action_name else im.module.actions.keys()
+    actions = act.call_set(action_name,im.module.actions) if action_name else list(im.module.actions.keys())
     for actname in actions:
         action = im.module.actions[actname]
         for a in action.iter_subactions():
@@ -146,7 +146,7 @@ def find_assertions(action_name=None):
 
 def show_assertions():
     for a in find_assertions():
-        print '{}: {}'.format(a.lineno,a)
+        print('{}: {}'.format(a.lineno,a))
 
 checked_action_found = False
 
@@ -163,7 +163,7 @@ def get_checked_actions():
 failures = 0
 
 def print_dots():
-    print '...',
+    print('...', end=' ')
     sys.stdout.flush()
     
 
@@ -210,7 +210,7 @@ class ConjChecker(Checker):
         self.indent = indent
         Checker.__init__(self,lf.formula)
     def start(self):
-        print pretty_lf(self.lf,self.indent),
+        print(pretty_lf(self.lf,self.indent), end=' ')
         print_dots()
     def get_annot(self):
         return self.lf.annot if hasattr(self.lf,'annot') else None
@@ -220,7 +220,7 @@ class ConjAssumer(Checker):
         self.lf = lf
         Checker.__init__(self,lf.formula,invert=False)
     def start(self):
-        print pretty_lf(self.lf) + "  [assumed]"
+        print(pretty_lf(self.lf) + "  [assumed]")
     def assume(self):
         return True
 
@@ -251,9 +251,9 @@ class MatchHandler(object):
         #         self.show_sym(sym,sym)
         self.started = False
         self.renaming = dict()
-        print
-        print 'Trace follows...'
-        print 80 * '*'
+        print()
+        print('Trace follows...')
+        print(80 * '*')
 
     def show_sym(self,sym,renamed_sym):
         if sym in self.renaming and self.renaming[sym] == renamed_sym:
@@ -267,7 +267,7 @@ class MatchHandler(object):
             if lhs in self.current and self.current[lhs] == rhs:
                 continue
             self.current[lhs] = rhs
-            print '    {}'.format(rfmla)
+            print('    {}'.format(rfmla))
         
     def eval(self,cond):
         truth = self.model.eval_to_constant(cond)
@@ -292,11 +292,11 @@ class MatchHandler(object):
                     if sym not in env and not itr.is_new(sym) and not self.is_skolem(sym):
                         self.show_sym(sym,sym)
                 self.started = True
-            for sym,renamed_sym in env.iteritems():
+            for sym,renamed_sym in env.items():
                 if not itr.is_new(sym) and not self.is_skolem(sym):
                     self.show_sym(sym,renamed_sym)
 
-            print '{}{}'.format(action.lineno,action)
+            print('{}{}'.format(action.lineno,action))
 
     def do_return(self,action,env):
         pass
@@ -351,7 +351,7 @@ def check_fcs_in_state(mod,ag,post,fcs):
             if not opt_trace.get():
                 gui_art(handler)
             else:
-                print str(handler)
+                print(str(handler))
             exit(0)
     else:
         res = history.satisfy(axioms,gmc,filter_fcs(fcs))
@@ -391,7 +391,7 @@ def apply_conj_proofs(mod):
         if lf.id in pmap:
             proof = pmap[lf.id]
             subgoals = pc.admit_proposition(lf,proof)
-            subgoals = map(ivy_compiler.theorem_to_property,subgoals)
+            subgoals = list(map(ivy_compiler.theorem_to_property,subgoals))
             conjs.extend(subgoals)
         else:
             conjs.append(lf)
@@ -425,20 +425,20 @@ def check_isolate():
         axioms = [m for m in mod.labeled_axioms if m.id not in subgoalmap] 
         schema_instances = [m for m in mod.labeled_axioms if m.id in subgoalmap]
         if axioms:
-            print "\n    The following properties are assumed as axioms:"
+            print("\n    The following properties are assumed as axioms:")
             for lf in axioms:
-                print pretty_lf(lf)
+                print(pretty_lf(lf))
 
         if mod.definitions:
-            print "\n    The following definitions are used:"
+            print("\n    The following definitions are used:")
             for lf in mod.definitions:
-                print pretty_lf(lf)
+                print(pretty_lf(lf))
 
         if (mod.labeled_props or schema_instances) and not checked_action.get():
-            print "\n    The following properties are to be checked:"
+            print("\n    The following properties are to be checked:")
             if check:
                 for lf in schema_instances:
-                    print pretty_lf(lf) + " [proved by axiom schema]"
+                    print(pretty_lf(lf) + " [proved by axiom schema]")
                 ag = ivy_art.AnalysisGraph()
                 clauses1 = lut.true_clauses(annot=act.EmptyAnnotation())
                 pre = itp.State(value = clauses1)
@@ -448,7 +448,7 @@ def check_isolate():
                 check_fcs_in_state(mod,ag,pre,fcs)
             else:
                 for lf in schema_instances + mod.labeled_props:
-                    print pretty_lf(lf)
+                    print(pretty_lf(lf))
 
         # after checking properties, make them axioms, except temporals
         im.module.labeled_axioms.extend(p for p in im.module.labeled_props if not p.temporal)
@@ -456,25 +456,25 @@ def check_isolate():
 
 
         if mod.labeled_inits:
-            print "\n    The following properties are assumed initially:"
+            print("\n    The following properties are assumed initially:")
             for lf in mod.labeled_inits:
-                print pretty_lf(lf)
+                print(pretty_lf(lf))
         if mod.labeled_conjs:
-            print "\n    The inductive invariant consists of the following conjectures:"
+            print("\n    The inductive invariant consists of the following conjectures:")
             for lf in mod.labeled_conjs:
-                print pretty_lf(lf)
+                print(pretty_lf(lf))
 
         apply_conj_proofs(mod)
 
         if mod.isolate_info is not None and mod.isolate_info.implementations:
-            print "\n    The following action implementations are present:"
+            print("\n    The following action implementations are present:")
             for mixer,mixee,action in sorted(mod.isolate_info.implementations,key=lambda x: x[0]):
-                print "        {}implementation of {}".format(pretty_lineno(action),mixee)
+                print("        {}implementation of {}".format(pretty_lineno(action),mixee))
 
         if mod.isolate_info is not None and mod.isolate_info.monitors:
-            print "\n    The following action monitors are present:"
+            print("\n    The following action monitors are present:")
             for mixer,mixee,action in sorted(mod.isolate_info.monitors,key=lambda x: x[0]):
-                print "        {}monitor of {}".format(pretty_lineno(action),mixee)
+                print("        {}monitor of {}".format(pretty_lineno(action),mixee))
 
         # if mod.actions:
         #     print "\n    The following actions are present:"
@@ -482,21 +482,21 @@ def check_isolate():
         #         print "        {}{}".format(pretty_lineno(action),actname)
 
         if mod.initializers:
-            print "\n    The following initializers are present:"
+            print("\n    The following initializers are present:")
             for actname,action in sorted(mod.initializers, key=lambda x: x[0]):
-                print "        {}{}".format(pretty_lineno(action),actname)
+                print("        {}{}".format(pretty_lineno(action),actname))
 
         if mod.labeled_conjs and not checked_action.get():
-            print "\n    Initialization must establish the invariant"
+            print("\n    Initialization must establish the invariant")
             if check:
                 with itp.EvalContext(check=False):
                     ag = ivy_art.AnalysisGraph(initializer=lambda x:None)
                     check_conjs_in_state(mod,ag,ag.states[0])
             else:
-                print ''
+                print('')
 
         if mod.initializers:
-            print "\n    Any assertions in initializers must be checked",
+            print("\n    Any assertions in initializers must be checked", end=' ')
             if check:
                 ag = ivy_art.AnalysisGraph(initializer=lambda x:None)
                 fail = itp.State(expr = itp.fail_expr(ag.states[0].expr))
@@ -506,10 +506,10 @@ def check_isolate():
         checked_actions = get_checked_actions()
 
         if checked_actions and mod.labeled_conjs:
-            print "\n    The following set of external actions must preserve the invariant:"
+            print("\n    The following set of external actions must preserve the invariant:")
             for actname in sorted(checked_actions):
                 action = act.env_action(actname)
-                print "        {}{}".format(pretty_lineno(action),actname)
+                print("        {}{}".format(pretty_lineno(action),actname))
                 if check:
                     ag = ivy_art.AnalysisGraph()
                     pre = itp.State()
@@ -519,52 +519,52 @@ def check_isolate():
                         post = ag.execute(action, pre)
                     check_conjs_in_state(mod,ag,post,indent=12)
                 else:
-                    print ''
+                    print('')
 
 
 
         callgraph = defaultdict(list)
-        for actname,action in mod.actions.iteritems():
+        for actname,action in mod.actions.items():
             for called_name in action.iter_calls():
                 callgraph[called_name].append(actname)
 
         some_assumps = False
-        for actname,action in mod.actions.iteritems():
+        for actname,action in mod.actions.items():
             assumptions = [sub for sub in action.iter_subactions()
                                if isinstance(sub,act.AssumeAction)]
             if assumptions:
                 if not some_assumps:
-                    print "\n    The following program assertions are treated as assumptions:"
+                    print("\n    The following program assertions are treated as assumptions:")
                     some_assumps = True
                 callers = callgraph[actname]
                 if actname in mod.public_actions:
                     callers.append("the environment")
                 prettyname = actname[4:] if actname.startswith('ext:') else actname
                 prettycallers = [c[4:] if c.startswith('ext:') else c for c in callers]
-                print "        in action {} when called from {}:".format(prettyname,','.join(prettycallers))
+                print("        in action {} when called from {}:".format(prettyname,','.join(prettycallers)))
                 for sub in assumptions:
-                    print "            {}assumption".format(pretty_lineno(sub))
+                    print("            {}assumption".format(pretty_lineno(sub)))
 
         tried = set()
         some_guarants = False
-        for actname,action in mod.actions.iteritems():
+        for actname,action in mod.actions.items():
             guarantees = [sub for sub in action.iter_subactions()
                               if isinstance(sub,(act.AssertAction,act.Ranking))]
             if check_lineno is not None:
                 guarantees = [sub for sub in guarantees if sub.lineno == check_lineno]
             if guarantees:
                 if not some_guarants:
-                    print "\n    The following program assertions are treated as guarantees:"
+                    print("\n    The following program assertions are treated as guarantees:")
                     some_guarants = True
                 callers = callgraph[actname]
                 if actname in mod.public_actions:
                     callers.append("the environment")
                 prettyname = actname[4:] if actname.startswith('ext:') else actname
                 prettycallers = [c[4:] if c.startswith('ext:') else c for c in callers]
-                print "        in action {} when called from {}:".format(prettyname,','.join(prettycallers))
+                print("        in action {} when called from {}:".format(prettyname,','.join(prettycallers)))
                 roots = set(iu.reachable([actname],lambda x: callgraph[x]))
                 for sub in guarantees:
-                    print "            {}guarantee".format(pretty_lineno(sub)),
+                    print("            {}guarantee".format(pretty_lineno(sub)), end=' ')
                     if check and any(r in roots and (r,sub.lineno) not in tried for r in checked_actions):
                         print_dots()
                         old_checked_assert = act.checked_assert.get()
@@ -584,10 +584,10 @@ def check_isolate():
                                    some_failed = True
                                    break
                         if not some_failed:
-                            print 'PASS'
+                            print('PASS')
                         act.checked_assert.value = old_checked_assert
                     else:
-                        print ""
+                        print("")
 
         check_temporals()
 
@@ -642,7 +642,7 @@ def check_subgoals(goals):
 def all_assert_linenos():
     mod = im.module
     all = []
-    for actname,action in mod.actions.iteritems():
+    for actname,action in mod.actions.items():
         guarantees = [sub.lineno for sub in action.iter_subactions()
                       if isinstance(sub,(act.AssertAction,act.Ranking))]
         all.extend(guarantees)
@@ -722,11 +722,11 @@ def check_module():
             if len(idef.verified()) == 0 or isinstance(idef,ivy_ast.TrustedIsolateDef):
                 continue # skip if nothing to verify
         if isolate:
-            print "\nIsolate {}:".format(isolate)
+            print("\nIsolate {}:".format(isolate))
         if isolate is not None and iu.compose_names(isolate,'macro_finder') in im.module.attributes:
             save_macro_finder = islv.opt_macro_finder.get()
             if save_macro_finder:
-                print "Turning off macro_finder"
+                print("Turning off macro_finder")
                 islv.set_macro_finder(False)
         with im.module.copy():
             ivy_isolate.create_isolate(isolate) # ,ext='ext'
@@ -746,9 +746,9 @@ def check_module():
                 check_isolate()
         if isolate is not None and iu.compose_names(isolate,'macro_finder') in im.module.attributes:
             if save_macro_finder:
-                print "Turning on macro_finder"
+                print("Turning on macro_finder")
                 islv.set_macro_finder(True)
-    print ''
+    print('')
     if failures > 0:
         raise iu.IvyError(None,"failed checks: {}".format(failures))
     if checked_action.get() and not checked_action_found:
@@ -760,7 +760,7 @@ def check_module():
 def main():
     import signal
     signal.signal(signal.SIGINT,signal.SIG_DFL)
-    import ivy_alpha
+    from . import ivy_alpha
     ivy_alpha.test_bottom = False # this prevents a useless SAT check
     ivy_init.read_params()
     if len(sys.argv) != 2 or not sys.argv[1].endswith('ivy'):
@@ -773,9 +773,9 @@ def main():
             ivy_init.source_file(sys.argv[1],ivy_init.open_read(sys.argv[1]),create_isolate=False)
             check_module()
     if some_bounded:
-        print "BOUNDED"
+        print("BOUNDED")
     else:
-        print "OK"
+        print("OK")
 
 
 if __name__ == "__main__":

--- a/ivy/ivy_compiler.py
+++ b/ivy/ivy_compiler.py
@@ -25,6 +25,7 @@ from . import ivy_printer
 from . import ivy_proof as ip
 from collections import defaultdict
 from tarjan import tarjan
+from importlib import reload
 
 opt_mutax = iu.BooleanParameter("mutax",False)
 

--- a/ivy/ivy_compiler.py
+++ b/ivy/ivy_compiler.py
@@ -1457,7 +1457,7 @@ def get_file_version(filename):
     except:
         raise IvyError(None,"not found: %s" % filename)
     header = f.readline()
-    header = string.strip(header)
+    header = header.strip()
     if header.startswith('#lang ivy'):
         version = header[len('#lang ivy'):]
         if version.strip() != '':
@@ -2127,7 +2127,7 @@ def read_module(f,nested=False):
     from . import ivy_parser
     header = f.readline()
     s = '\n' + f.read() # newline at beginning to preserve line numbers
-    header = string.strip(header)
+    header = header.strip()
     if header.startswith('#lang ivy'):
         version = header[len('#lang ivy'):]
         if version.strip() != '':

--- a/ivy/ivy_compiler.py
+++ b/ivy/ivy_compiler.py
@@ -1,28 +1,28 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_art import *
+from .ivy_art import *
 import pickle
-from ivy_interp import Interp, eval_state_facts
+from .ivy_interp import Interp, eval_state_facts
 from functools import partial
-from ivy_concept_space import *
-from ivy_parser import parse,ConstantDecl,ActionDef,Ivy,inst_mod
-from ivy_actions import DerivedUpdate, type_check_action, type_check, SymbolList, UpdatePattern, ActionContext, LocalAction, AssignAction, CallAction, Sequence, IfAction, WhileAction, AssertAction, AssumeAction, NativeAction, ChoiceAction, CrashAction, ThunkAction, has_code
-from ivy_utils import IvyError
-import ivy_logic
-import ivy_dafny_compiler as dc
-import ivy_solver as slv
-import ivy_logic_utils as lu
+from .ivy_concept_space import *
+from .ivy_parser import parse,ConstantDecl,ActionDef,Ivy,inst_mod
+from .ivy_actions import DerivedUpdate, type_check_action, type_check, SymbolList, UpdatePattern, ActionContext, LocalAction, AssignAction, CallAction, Sequence, IfAction, WhileAction, AssertAction, AssumeAction, NativeAction, ChoiceAction, CrashAction, ThunkAction, has_code
+from .ivy_utils import IvyError
+from . import ivy_logic
+from . import ivy_dafny_compiler as dc
+from . import ivy_solver as slv
+from . import ivy_logic_utils as lu
 import string
-import ivy_ast
-import ivy_utils as iu
-import ivy_actions as ia
-import ivy_alpha
-import ivy_module as im
-import ivy_theory as ith
-import ivy_isolate as iso
-import ivy_printer
-import ivy_proof as ip
+from . import ivy_ast
+from . import ivy_utils as iu
+from . import ivy_actions as ia
+from . import ivy_alpha
+from . import ivy_module as im
+from . import ivy_theory as ith
+from . import ivy_isolate as iso
+from . import ivy_printer
+from . import ivy_proof as ip
 from collections import defaultdict
 from tarjan import tarjan
 
@@ -39,7 +39,7 @@ class IvyDeclInterp(object):
                     for x in decl.args:
                         getattr(self,n)(x)
 
-from ivy_ast import ASTContext
+from .ivy_ast import ASTContext
 
 # ast compilation
 
@@ -133,7 +133,7 @@ class EmptyVariableContext(object):
 
 class VariableContext(Context):
     def __init__(self,vs):
-        self.map = dict(variable_context.map.iteritems())
+        self.map = dict(iter(variable_context.map.items()))
         for v in vs:
             self.map[v.name] = v.sort
         self.name = 'variable_context'
@@ -623,12 +623,12 @@ IfAction.cmpl = compile_if_action
 def compile_while_action(self):
         if isinstance(self.args[0],ivy_ast.Some):
             res = compile_if_action(self.clone(self.args[:2]))
-            invars = map(sortify_with_inference,self.args[2:])
+            invars = list(map(sortify_with_inference,self.args[2:]))
             return res.clone(res.args+invars)
         ctx = ExprContext(lineno = self.lineno)
         with ctx:
             cond = sortify_with_inference(self.args[0])
-            invars = map(sortify_with_inference,self.args[2:])
+            invars = list(map(sortify_with_inference,self.args[2:]))
         body = self.args[1].compile()
         if ctx.code:
             raise iu.IvyError(self,'while condition may not contain action calls')
@@ -658,7 +658,7 @@ def compile_crash_action(self):
     name = self.args[0].rep
     if isinstance(name,ivy_ast.This):
         name = 'this'
-    thing = ivy_ast.Atom(name,map(sortify_with_inference,self.args[0].args))
+    thing = ivy_ast.Atom(name,list(map(sortify_with_inference,self.args[0].args)))
     res = self.clone([thing])
     return res
 
@@ -727,7 +727,7 @@ def compile_native_arg(arg):
         return sortify_with_inference(arg)
     if arg.rep in ivy_logic.sig.symbols:
         return sortify_with_inference(arg)
-    res = arg.clone(map(sortify_with_inference,arg.args)) # handles action names
+    res = arg.clone(list(map(sortify_with_inference,arg.args))) # handles action names
     return res.rename(resolve_alias(res.rep))
 
 
@@ -765,7 +765,7 @@ def compile_native_def(self):
 def compile_action_def(a,sig):
     sig = sig.copy()
     if not hasattr(a.args[1],'lineno'):
-        print a
+        print(a)
     assert hasattr(a.args[1],'lineno')
     with sig:
         with ASTContext(a.args[1]):
@@ -831,7 +831,7 @@ def compile_defn(df):
     
 def compile_schema_prem(self,sig):
     if isinstance(self,ivy_ast.ConstantDecl):
-        with ivy_logic.WithSorts(sig.sorts.values()):
+        with ivy_logic.WithSorts(list(sig.sorts.values())):
             sym = compile_const(self.args[0],sig)
         return self.clone([sym])
     elif isinstance(self,ivy_ast.DerivedDecl):
@@ -842,7 +842,7 @@ def compile_schema_prem(self,sig):
         return t
     elif isinstance(self,ivy_ast.LabeledFormula):
         with ivy_logic.WithSymbols(sig.all_symbols()):
-            with ivy_logic.WithSorts(sig.sorts.values()):
+            with ivy_logic.WithSorts(list(sig.sorts.values())):
                 return self.compile()
     # elif isinstance(self,ivy_ast.SchemaBody):
     #     with ivy_logic.WithSymbols(sig.all_symbols()):
@@ -851,7 +851,7 @@ def compile_schema_prem(self,sig):
     
 def compile_schema_conc(self,sig):
     with ivy_logic.WithSymbols(sig.all_symbols()):
-        with ivy_logic.WithSorts(sig.sorts.values()):
+        with ivy_logic.WithSorts(list(sig.sorts.values())):
             if isinstance(self,ivy_ast.Definition):
                 return compile_defn(self)
             return sortify_with_inference(self)
@@ -900,7 +900,7 @@ def compile_schema_instantiation(self,fmla):
             sorted_pairs.append((x,y))
 
     return self.clone([self.args[0]]+
-                      [ivy_ast.Definition(x,y) for x,y in sortmap.iteritems()] +
+                      [ivy_ast.Definition(x,y) for x,y in sortmap.items()] +
                       [ivy_ast.Definition(x,y) for x,y in sorted_pairs])
 
 last_fmla = None
@@ -1388,7 +1388,7 @@ class IvyARGSetup(IvyDeclInterp):
             iact.lineno = scen.lineno
             self.mod.actions[iname] = iact
             self.mixin(ivy_ast.MixinAfterDef(ivy_ast.Atom(iname),ivy_ast.Atom('init')))
-        for actname,trs in transs_by_action.iteritems():
+        for actname,trs in transs_by_action.items():
             choices = []
             params = None
             afters = []
@@ -1422,7 +1422,7 @@ class IvyARGSetup(IvyDeclInterp):
                     mixee = scmix.args[1].args[0]
                 else:
                     aparams = df.formal_params + df.formal_returns
-                    subst = dict(zip(aparams,params+returns))
+                    subst = dict(list(zip(aparams,params+returns)))
                     seq = substitute_constants_ast(seq,subst)
                 seq.lineno = tr.lineno
                 if not is_after:
@@ -1597,14 +1597,14 @@ def attach_proofs(mod):
         if pf[0].formula is None:
             lab = pf[0].label.rep
             if lab in used:
-                raise(IvyError(pf[1],'redundant proof for {}'.format(lab)))
+                raise IvyError
             used.add(lab)
             if lab in m:
                 mod.proofs.append((m[lab],pf[1]))
             elif lab in mod.isolates:
                 mod.isolate_proofs[lab] = pf[1]
             else:
-                raise(IvyError(pf[1],'proof label {} is not a property or isolate'.format(lab)))
+                raise IvyError
         
                 
 def check_definitions(mod):
@@ -1651,7 +1651,7 @@ def check_definitions(mod):
     
     if iu.version_le("1.7",iu.get_string_version()):
         side_effects = dict()
-        for action in mod.actions.values():
+        for action in list(mod.actions.values()):
             for sub in action.iter_subactions():
                 for s in sub.modifies():
                     if s not in side_effects:
@@ -1677,7 +1677,7 @@ def check_definitions(mod):
     dmap = dict((d.formula.defines(),d) for d in mod.definitions)
     pmap = dict((lf.id,p) for lf,p in mod.proofs)
     sccs = tarjan_arcs(arcs)
-    import ivy_proof
+    from . import ivy_proof
     prover = ivy_proof.ProofChecker(mod.labeled_axioms,[],mod.schemata)
     for scc in sccs:
         if len(scc) > 1:
@@ -1769,8 +1769,8 @@ def reorder_props(mod,props):
         
 
 def create_constructor_schemata(mod):
-    import ivy_proof
-    for sortname,destrs in mod.sort_destructors.iteritems():
+    from . import ivy_proof
+    for sortname,destrs in mod.sort_destructors.items():
         if any(len(f.sort.dom) > 1 for f in destrs):
             continue # TODO: higher-order constructors!
         sort = ivy_logic.find_sort(sortname)
@@ -1807,7 +1807,7 @@ def create_constructor_schemata(mod):
             goal.lineno = None
             mod.schemata[name.relname] = goal
 
-    for sortname,conss in mod.sort_constructors.iteritems():
+    for sortname,conss in mod.sort_constructors.items():
         for cons in conss:
             if sortname not in mod.sort_destructors:
                 raise iu.IvyError(cons,"Cannot define constructor {} for type {} because {} is not a structure type".format(cons,sortname,sortname))
@@ -1824,7 +1824,7 @@ def apply_assert_proofs(mod,prover):
                 goal = ivy_ast.LabeledFormula(None,cond)
                 goal.lineno = self.lineno
                 subgoals = prover.get_subgoals(goal,pf)
-                subgoals = map(theorem_to_property,subgoals)
+                subgoals = list(map(theorem_to_property,subgoals))
                 assm = AssumeAction(ivy_logic.close_formula(cond))
                 assm.lineno = self.lineno
                 sgas = [ia.SubgoalAction(sg.formula) for sg in subgoals]
@@ -1839,8 +1839,8 @@ def apply_assert_proofs(mod,prover):
             return self
         if isinstance(self,LocalAction):
             with ivy_logic.WithSymbols(self.args[0:-1]):
-                return self.clone(map(recur,self.args))
-        return self.clone(map(recur,self.args))
+                return self.clone(list(map(recur,self.args)))
+        return self.clone(list(map(recur,self.args)))
     for actname in list(mod.actions.keys()):
         action = mod.actions[actname]
         with ivy_logic.WithSymbols(list(set(action.formal_params+action.formal_returns))):
@@ -1873,7 +1873,7 @@ def check_properties(mod):
             prop = prop.clone([prop.label,fmla])
         return prop
             
-    import ivy_proof
+    from . import ivy_proof
     prover = ivy_proof.ProofChecker(mod.labeled_axioms,mod.definitions,mod.schemata)
 
     for prop in props:
@@ -1894,7 +1894,7 @@ def check_properties(mod):
                 else:
                     mod.schemata[prop.label.relname] = prop
             else:
-                subgoals = map(theorem_to_property,subgoals)
+                subgoals = list(map(theorem_to_property,subgoals))
                 lb = ivy_ast.Labeler()
                 for g in subgoals:
                     if prop.label is None:
@@ -1934,8 +1934,8 @@ def ivy_compile_theory(mod,decls,**kwargs):
     IvyDomainSetup(mod)(decls)
     
 def ivy_compile_theory_from_string(mod,theory,sortname,**kwargs):
-    import StringIO
-    sio = StringIO.StringIO(theory)
+    import io
+    sio = io.StringIO(theory)
     module = read_module(sio)
     ivy = Ivy()
     inst_mod(ivy,module,None,{'t':sortname},dict())
@@ -1947,7 +1947,7 @@ def compile_theory(mod,sortname,theoryname,**kwargs):
         ivy_compile_theory_from_string(mod,theory,sortname,**kwargs)
     
 def compile_theories(mod,**kwargs):
-    for name,value in mod.sig.interp.iteritems():
+    for name,value in mod.sig.interp.items():
         if name in mod.sig.sorts and isinstance(value,str):
             theory = th.get_theory_schemata(value)
             ivy_compile_theory_from_string(mod,theory,name,**kwargs)
@@ -1966,7 +1966,7 @@ def create_conj_actions(mod):
     myexports = dict()
     objects = defaultdict(list)
     cg = mod.call_graph()
-    for ison,isol in mod.isolates.iteritems():
+    for ison,isol in mod.isolates.items():
         myexports[isol.name()] = iso.get_isolate_exports(mod,cg,isol)
         for x in isol.verified():
             objects[x.rep].append(isol)
@@ -1986,10 +1986,10 @@ def create_conj_actions(mod):
     # check that object invariants are used correctly
     
     if iso.do_check_interference.get():
-        for ison,actions in myexports.iteritems():
+        for ison,actions in myexports.items():
             for action in actions:
                 action_isos[action].add(ison)
-        for ison,isol in mod.isolates.iteritems():
+        for ison,isol in mod.isolates.items():
             memo = set()
             conjs = iso.get_isolate_conjs(mod,isol,verified=False)
             exports = myexports[ison]
@@ -2038,14 +2038,14 @@ def handle_temporals(mod):
             add_labels_to_proof(proof,isonames)
     mod.labeled_props = new_props
     imap = iso.get_isolate_map(mod,verified=True,present=True)
-    for actname,action in mod.actions.iteritems():
+    for actname,action in mod.actions.items():
         action.labels = imap[actname]
 
 def add_labels_to_proof(proof,labels):
     if isinstance(proof,ivy_ast.ComposeTactics):
-        return proof.clone(map(add_labels_to_proof,proof.args))
+        return proof.clone(list(map(add_labels_to_proof,proof.args)))
     if isinstance(proof,ivy_ast.IfTactic):
-        return proof.clone([proof.args[0]] + map(add_labels_to_proof,proof.args[1:]))
+        return proof.clone([proof.args[0]] + list(map(add_labels_to_proof,proof.args[1:])))
     if isinstance(proof,ivy_ast.TacticTactic):
         proof.labels = list(labels)
     return proof
@@ -2057,8 +2057,8 @@ def add_action_label(action,label):
     action.labels.append(label)
 
 def show_call_graph(cg):
-    for caller,callees in cg.iteritems():
-        print '{} -> {}'.format(caller,','.join(callees))
+    for caller,callees in cg.items():
+        print('{} -> {}'.format(caller,','.join(callees)))
     
 def ivy_compile(decls,mod=None,create_isolate=True,**kwargs):
     mod = mod or im.module
@@ -2082,11 +2082,11 @@ def ivy_compile(decls,mod=None,create_isolate=True,**kwargs):
             remove_symbol(p.defines())
         mod.type_check()
         # try instantiating all the actions to type check them
-        for name,action in mod.actions.iteritems():
+        for name,action in mod.actions.items():
 #            print "checking: {} = {}".format(name,action)
             type_check_action(action,mod)
             if not hasattr(action,'lineno'):
-                print "no lineno: {}".format(name)
+                print("no lineno: {}".format(name))
             assert hasattr(action,'formal_params'), action
     
         # from version 1.7, there is always one global "isolate"
@@ -2123,8 +2123,8 @@ def clear_rules(modname):
             del d[s]
 
 def read_module(f,nested=False):
-    import ivy_logic_parser
-    import ivy_parser
+    from . import ivy_logic_parser
+    from . import ivy_parser
     header = f.readline()
     s = '\n' + f.read() # newline at beginning to preserve line numbers
     header = string.strip(header)
@@ -2172,7 +2172,7 @@ def ivy_load_file(f,**kwargs):
     ivy_compile(decls,**kwargs)
 
 def ivy_from_string(string,**kwargs):
-    import StringIO
-    sio = StringIO.StringIO(string)
+    import io
+    sio = io.StringIO(string)
     ivy_load_file(sio,**kwargs)
     return ivy_new()

--- a/ivy/ivy_compiler.py
+++ b/ivy/ivy_compiler.py
@@ -1449,8 +1449,8 @@ class IvyARGSetup(IvyDeclInterp):
 def BalancedChoice(choices):
     if len(choices) == 1:
         return choices[0]
-    return ChoiceAction(BalancedChoice(choices[0:len(choices)/2]),
-                        BalancedChoice(choices[len(choices)/2:]))
+    return ChoiceAction(BalancedChoice(choices[0:len(choices)//2]),
+                        BalancedChoice(choices[len(choices)//2:]))
 
 def get_file_version(filename):
     try:

--- a/ivy/ivy_concept_space.py
+++ b/ivy/ivy_concept_space.py
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 import itertools
-from ivy_logic import *
-from ivy_logic_utils import substitute_clause, canonize_clause, used_variables_clauses
+from .ivy_logic import *
+from .ivy_logic_utils import substitute_clause, canonize_clause, used_variables_clauses
 
 class NamedSpace(AST):
     def __init__(self, lit):
@@ -16,7 +16,7 @@ class NamedSpace(AST):
         if self.lit.polarity == 1 and is_atom(atom) and atom.relname in memo:
             params,value = memo[atom.relname]
             assert len(params) == len(atom.args)
-            subst = dict(zip(params,atom.args))
+            subst = dict(list(zip(params,atom.args)))
             res = [substitute_clause(cl,subst) for cl in value]
 #            print "blif: {} {} {} {}".format(atom,params,value,res)
             return res
@@ -26,9 +26,9 @@ class NamedSpace(AST):
         if self.lit.polarity == 1 and atom.relname in memo:
             params,value = memo[atom.relname]
             if len(params) != len(atom.args):
-                print "{} {} {}".format(self,params,value)
+                print("{} {} {}".format(self,params,value))
             assert len(params) == len(atom.args)
-            subst = dict(zip(params,atom.args))
+            subst = dict(list(zip(params,atom.args)))
             return [(substitute_clause(cl,subst),relalg.subst(r,subst)) for (cl,r) in value]
         v = relalg.prim(self.lit)
         return [([self.lit],v)] if not relalg.empty(v) else []
@@ -110,7 +110,7 @@ def t_SYMBOL(t):
     return t
 
 def t_error(t):
-    print "Illegal character '%s'" % t.value[0]
+    print("Illegal character '%s'" % t.value[0])
     t.lexer.skip(1)
 
 lexer = lex.lex()
@@ -180,7 +180,7 @@ def p_sum_sum_expr(p):
 
     
 def p_error(p):
-    print "Syntax error in input!"
+    print("Syntax error in input!")
 
 # Build the parser
 import os
@@ -193,13 +193,13 @@ def to_concept_space(s):
 if __name__ == '__main__':
     while True:
        try:
-           s = raw_input('calc > ')
+           s = input('calc > ')
        except EOFError:
            break
        if not s: continue
        result = parser.parse(s)
-       print result
-       print "enum: %s" % result.enumerate(dict(),lambda x:True)
+       print(result)
+       print("enum: %s" % result.enumerate(dict(),lambda x:True))
 
 def clauses_to_concept(name,clauses):
     vars =  used_variables_clauses(clauses)

--- a/ivy/ivy_congclos.py
+++ b/ivy/ivy_congclos.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_logic import *
+from .ivy_logic import *
 from collections import defaultdict
 
 class UndoRep(object):
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     c.union(to_term("v"),to_term("w"))
     c.push()
     c.union(to_term("u"),to_term("v"))
-    print c.find(to_term("w"))
+    print(c.find(to_term("w")))
     c.pop()
-    print c.tab
-    print c.theory()
+    print(c.tab)
+    print(c.theory())

--- a/ivy/ivy_core.py
+++ b/ivy/ivy_core.py
@@ -11,7 +11,7 @@ def get_id(x):
 
 def biased_core(s,alits,unlikely):
     """ Try to produce a minimal unsatisfiable subset of alits, using as few
-    of the alits in unlikely as possible. 
+    of the alits in unlikely as possible.
     """
     core = alits
     for lit in unlikely:
@@ -22,22 +22,22 @@ def biased_core(s,alits,unlikely):
     assert is_sat == unsat
     core = minimize_core(s)
     return core
-    
+
 
 def minimize_core_aux2(s, core):
     mus = []
     ids = {}
     while core != []:
-	c = core[0]
-	new_core = mus + core[1:]
-	is_sat = s.check(new_core)
-	if is_sat == sat:
-	    mus = mus + [c]
-	    ids[get_id(c)] = True
-	    core = core[1:]
-	else:
-	    core = s.unsat_core()
-	    core = [c for c in core if get_id(c) not in ids]
+        c = core[0]
+        new_core = mus + core[1:]
+        is_sat = s.check(new_core)
+        if is_sat == sat:
+            mus = mus + [c]
+            ids[get_id(c)] = True
+            core = core[1:]
+        else:
+            core = s.unsat_core()
+            core = [c for c in core if get_id(c) not in ids]
     return mus
 
 def minimize_core(s):

--- a/ivy/ivy_core.py
+++ b/ivy/ivy_core.py
@@ -4,7 +4,7 @@
 # TODO get rid of import *
 
 from z3 import *
-import ivy_utils as iu
+from . import ivy_utils as iu
 
 def get_id(x):
     return Z3_get_ast_id(x.ctx_ref(), x.as_ast())

--- a/ivy/ivy_cpp.py
+++ b/ivy/ivy_cpp.py
@@ -407,8 +407,8 @@ if __name__ == "__main__":
         with CppClass("other_class"):
             CppMember(myvec,"bif")
             
-        print 'header:'
-        print context.globals.get()
-        print 'impl:'
-        print context.impls.get()
+        print('header:')
+        print(context.globals.get())
+        print('impl:')
+        print(context.impls.get())
         

--- a/ivy/ivy_cpp_types.py
+++ b/ivy/ivy_cpp_types.py
@@ -4,10 +4,10 @@
 
 # A collection of C++ types used to model IVy types in compiled code.
 
-from ivy_cpp import *
-import ivy_utils as iu
-import ivy_solver
-import ivy_logic
+from .ivy_cpp import *
+from . import ivy_utils as iu
+from . import ivy_solver
+from . import ivy_logic
 
 class XBV(CppClass):
     """ A type that represents a large type t using a bit vector. It

--- a/ivy/ivy_dafny_ast.py
+++ b/ivy/ivy_dafny_ast.py
@@ -9,7 +9,7 @@ class AST(object):
     def __init__(self,*args):
         self.args = args
     def __repr__(self):
-        d = "{%s}" % ', '.join( "%s: %s" % (k,v) for k,v in self.__dict__.iteritems())
+        d = "{%s}" % ', '.join( "%s: %s" % (k,v) for k,v in self.__dict__.items())
         return "%s %s" % (type(self).__name__, d)
     def clone(self,args):
         res = type(self)(*args)

--- a/ivy/ivy_dafny_ast.py
+++ b/ivy/ivy_dafny_ast.py
@@ -105,7 +105,7 @@ class App(Expr):
             res.lineno = self.lineno
         return res
 
-class True(Expr):
+class True_(Expr):
     def __repr__(self):
         return "true"
 

--- a/ivy/ivy_dafny_compiler.py
+++ b/ivy/ivy_dafny_compiler.py
@@ -1,9 +1,9 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-import ivy_dafny_ast as da
-import ivy_parser as ip
-import ivy_utils as iu
+from . import ivy_dafny_ast as da
+from . import ivy_parser as ip
+from . import ivy_utils as iu
 
 class Context(object):
     def __enter__(self):
@@ -38,7 +38,7 @@ class ScopeContext(Context):
     def __init__(self):
         # copy existing local variabes if any
         if 'scope_context' in globals() and scope_context:
-            self.locals = dict(scope_context.locals.iteritems())
+            self.locals = dict(iter(scope_context.locals.items()))
         else:
             self.locals = dict()
         self.new_locals = []
@@ -218,7 +218,7 @@ def get_while_modset(mods):
     if mods:
         return [ip.Atom(s.to_ivy([]).rep,[]) for s in mods]
     elif method_context.modifies:
-        return method_context.modifies + [ip.Atom(y.rep,[]) for x,y in scope_context.locals.iteritems()]
+        return method_context.modifies + [ip.Atom(y.rep,[]) for x,y in scope_context.locals.items()]
     return None
 
 def whilestmt(s):
@@ -428,7 +428,7 @@ def subst_symbols_app(s,m):
 
 da.App.subst_symbols = subst_symbols_app
 
-import ivy_dafny_parser as dp
+from . import ivy_dafny_parser as dp
 
 preamble = """
 type int
@@ -454,7 +454,7 @@ def parse_to_ivy(s):
     im = ip.parse(preamble)
     with ModuleContext(dm,im):
         dm.to_ivy()
-        print im
+        print(im)
         return im
 
 if __name__ == "__main__":
@@ -473,6 +473,6 @@ if __name__ == "__main__":
         im = ip.Ivy()
         with ModuleContext(dm,im):
             dm.to_ivy()
-            print im
+            print(im)
 
     

--- a/ivy/ivy_dafny_grammar.py
+++ b/ivy/ivy_dafny_grammar.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-import ivy_dafny_ast as da
+from . import ivy_dafny_ast as da
 
 #### TODO: ghost, static, this, constructor
 

--- a/ivy/ivy_dafny_lexer.py
+++ b/ivy/ivy_dafny_lexer.py
@@ -95,7 +95,7 @@ def t_SYMBOL(t):
     return t
 
 def t_error(t):
-    print "Illegal character '%s'" % t.value[0]
+    print("Illegal character '%s'" % t.value[0])
     t.lexer.skip(1)
 
 lexer = lex.lex()

--- a/ivy/ivy_dafny_parser.py
+++ b/ivy/ivy_dafny_parser.py
@@ -1,9 +1,9 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_dafny_lexer import *
-from ivy_dafny_grammar import *
-from ivy_utils import p_error, parse_with
+from .ivy_dafny_lexer import *
+from .ivy_dafny_grammar import *
+from .ivy_utils import p_error, parse_with
 
 import ply.yacc as yacc
 
@@ -15,4 +15,4 @@ def parse(s):
     return parse_with(s,parser,lexer)
 
 if __name__ == "__main__":
-    print parser.parse('var x : y; method P(x:T) ensures x == y; {x := y;}')
+    print(parser.parse('var x : y; method P(x:T) ensures x == y; {x := y;}'))

--- a/ivy/ivy_dump.py
+++ b/ivy/ivy_dump.py
@@ -7,16 +7,16 @@ import z3_find_cons
 import analysis3 as analysis
 from functools import partial
 from concept_space import *
-from ivy_parser import parse
+from .ivy_parser import parse
 
-from ivy_parser import Ivy,Decl,AxiomDecl,RelationDecl,ConstantDecl,DerivedDecl,ConceptDecl,ActionDecl,InitDecl,ActionDef
-import ivy_actions
+from .ivy_parser import Ivy,Decl,AxiomDecl,RelationDecl,ConstantDecl,DerivedDecl,ConceptDecl,ActionDecl,InitDecl,ActionDef
+from . import ivy_actions
 
 def ivy_dump_file(f,ag):
     f.write('#lang ivy1\n')
     ivy = Ivy()
     d = ag.domain
-    for r,arity in d.relations.iteritems():
+    for r,arity in d.relations.items():
         ivy.declare(RelationDecl(rel_inst(r,arity)))
     for v in ag.pvars:
         ivy.declare(ConstantDecl(Constant(v)))
@@ -27,34 +27,34 @@ def ivy_dump_file(f,ag):
     for s in ag.states:
         if s.pred == None:
             ivy.declare(InitDecl(clauses_to_formula(s.clauses)))
-    for n,a in ag.actions.iteritems():
+    for n,a in ag.actions.items():
         ivy.declare(ActionDecl(ActionDef(n,a)))
     for c,df in d.concept_spaces:
         ivy.declare(ConceptDecl(Definition(c,df)))
     f.write(repr(ivy))
 
 if len(sys.argv) != 3:
-    print "usage: %s infile.a2g outfile.ivy" % sys.argv[0]
+    print("usage: %s infile.a2g outfile.ivy" % sys.argv[0])
     exit(1)
 
 if sys.argv[1].endswith('.a2g'):
     f = open(sys.argv[1],'rU')
     if not f:
-        print "not found: %s" % sys.argv[1]
+        print("not found: %s" % sys.argv[1])
         exit(1)
     ag = pickle.load(f)
     f.close()
 else:
-    print "input file must be .a2g"
+    print("input file must be .a2g")
     exit(1)
 
 if sys.argv[2].endswith('.ivy'):
     f = open(sys.argv[2],'w')
     if not f:
-        print "cannot write to: %s" % sys.argv[2]
+        print("cannot write to: %s" % sys.argv[2])
         exit(1)
     ivy_dump_file(f,ag)
     f.close()
 else:
-    print "output file must be .ivy"
+    print("output file must be .ivy")
     exit(1)

--- a/ivy/ivy_ev_parser.py
+++ b/ivy/ivy_ev_parser.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 import itertools
-import ivy_utils as iu
+from . import ivy_utils as iu
 
 def mymap(fun,obj):
     res = obj.map(fun)
@@ -132,15 +132,15 @@ class DictValue(dict):
         return str(self)
     @property
     def subs(self):
-        return [DictEntry(entry) for entry in self.iteritems()]
+        return [DictEntry(entry) for entry in self.items()]
     def __str__(self):
-        return '{' + ','.join(x + ':' + str(y) for x,y in self.iteritems()) + '}'
+        return '{' + ','.join(x + ':' + str(y) for x,y in self.items()) + '}'
     def match(self,d,binding=None):
         return (isinstance(d,Symbol) and (d.name == '*')
                 or (isinstance(d,DictValue)
-                    and all(k in self and self[k].match(v,binding) for k,v in d.iteritems())))
+                    and all(k in self and self[k].match(v,binding) for k,v in d.items())))
     def map(self,fun):
-        return type(self)(*[(x,mymap(fun,y)) for x,y in self.iteritems()])
+        return type(self)(*[(x,mymap(fun,y)) for x,y in self.items()])
 
 class EventGen(object):
     def __call__(self,evs):
@@ -163,7 +163,7 @@ class EventRevGen(object):
                 yield cs[0],thing
         else:
             num = len(things)
-        for idx in xrange(num-1,-1,-1):
+        for idx in range(num-1,-1,-1):
             thing = things[idx]
             for a,t in self.rec(thing.children,None,start=1):
                 yield str(idx+start)+'/'+a,t
@@ -278,7 +278,7 @@ def t_SYMBOL(t):
     return t
 
 def t_error(t):
-    print "Illegal character '%s'" % t.value[0]
+    print("Illegal character '%s'" % t.value[0])
     t.lexer.skip(1)
 
 lexer = lex.lex()
@@ -408,7 +408,7 @@ def parse(s):
     error_list = []
     res = parser.parse(s)
     if error_list:
-        print error_list
+        print(error_list)
         raise iu.ErrorList(error_list)
     return res
     
@@ -422,7 +422,7 @@ parser = yacc.yacc(tabmodule='ev_parsetab',errorlog=yacc.NullLogger(),outputdir=
 if __name__ == '__main__':
     while True:
        try:
-           s = raw_input('events > ')
+           s = input('events > ')
        except EOFError:
            break
        if not s: continue
@@ -431,13 +431,13 @@ if __name__ == '__main__':
 #       for a,x in EventFwdGen("2/2")(result):
 #           print a + ':' + x.text()
        try:
-           patstring = raw_input('patterns > ')
+           patstring = input('patterns > ')
        except EOFError:
            break
        if not s: continue
        pats = parser.parse(patstring)
        for e,b in bind(EventGen()(result),pats):
-           print 'event: {} binding: {}'.format(e,list((n,str(v)) for n,v in b.iteritems()))
+           print('event: {} binding: {}'.format(e,list((n,str(v)) for n,v in b.items())))
            
            
 

--- a/ivy/ivy_ev_viewer.py
+++ b/ivy/ivy_ev_viewer.py
@@ -1,8 +1,8 @@
 
-import Tix, os, tkFileDialog
-import ivy_ev_parser as ev
-import ivy_utils as iu
-import ivy_ui_util as uu
+import tkinter.tix, os, tkinter.filedialog
+from . import ivy_ev_parser as ev
+from . import ivy_utils as iu
+from . import ivy_ui_util as uu
 
 import signal
 signal.signal(signal.SIGINT,signal.SIG_DFL)
@@ -32,10 +32,10 @@ def do_ask_pat(fun,pattern):
             raise iu.IvyError(None,'syntax error')
         fun(pat_evs) 
 
-class EventTree(Tix.Tree,uu.WithMenuBar):
+class EventTree(tkinter.tix.Tree,uu.WithMenuBar):
     def __init__(self,root,notebook,evs):
         uu.WithMenuBar.__init__(self,root)
-        Tix.Tree.__init__(self,root,options='separator "/"')
+        tkinter.tix.Tree.__init__(self,root,options='separator "/"')
         self.evs = evs
         self.notebook = notebook
         for idx,entry in enumerate(evs):
@@ -86,9 +86,9 @@ class EventTree(Tix.Tree,uu.WithMenuBar):
             opendir(self,cs[0],self.evs)
         
         
-class EventNoteBook(Tix.NoteBook):
+class EventNoteBook(tkinter.tix.NoteBook):
     def __init__(self,root):
-        Tix.NoteBook.__init__(self,root)
+        tkinter.tix.NoteBook.__init__(self,root)
         self.num_sheets = 0
         self.root = root
         self.sheets = {}
@@ -97,7 +97,7 @@ class EventNoteBook(Tix.NoteBook):
         tab = self.add(name,label="Sheet {}".format(self.num_sheets)) 
         self.num_sheets += 1
         tree = EventTree(tab,self,evs)
-        tree.pack(expand=1, fill=Tix.BOTH, padx=10, pady=10, side=Tix.LEFT)
+        tree.pack(expand=1, fill=tkinter.tix.BOTH, padx=10, pady=10, side=tkinter.tix.LEFT)
         tree.hlist.configure(selectforeground='red')
         tree['opencmd'] = lambda dir=None, w=tree, t=evs: opendir(w, dir, t)
         tree['browsecmd'] = lambda dir=None, w=tree, t=evs: browsedir(w, dir, t)
@@ -110,28 +110,28 @@ class EventNoteBook(Tix.NoteBook):
     def current(self):
         return self.sheets[self.raised()]
 
-class PatternList(Tix.Frame):
+class PatternList(tkinter.tix.Frame):
     def __init__(self,root,notebook):
-        Tix.Frame.__init__(self,root)
-        bbox = Tix.Frame(self)
-        bts = [Tix.Button(bbox, text=t, command=c) for t,c in [
+        tkinter.tix.Frame.__init__(self,root)
+        bbox = tkinter.tix.Frame(self)
+        bts = [tkinter.tix.Button(bbox, text=t, command=c) for t,c in [
             ("<<",self.reverse),
             (">>",self.forward),
             ("+",self.plus),
             ("-",self.minus),]]
-        bbox.pack(side=Tix.TOP, fill=Tix.X)
+        bbox.pack(side=tkinter.tix.TOP, fill=tkinter.tix.X)
         for bt in bts:
-            bt.pack(side=Tix.LEFT, fill=Tix.X)
-        tlist = Tix.TList(self)
-        tlist.pack(expand=1, fill=Tix.BOTH, pady=10, side=Tix.TOP)
-        bbox = Tix.Frame(self)
-        bts = [Tix.Button(bbox, text=t, command=c) for t,c in [
+            bt.pack(side=tkinter.tix.LEFT, fill=tkinter.tix.X)
+        tlist = tkinter.tix.TList(self)
+        tlist.pack(expand=1, fill=tkinter.tix.BOTH, pady=10, side=tkinter.tix.TOP)
+        bbox = tkinter.tix.Frame(self)
+        bts = [tkinter.tix.Button(bbox, text=t, command=c) for t,c in [
             ("Save",self.save),
             ("Load",self.load),
             ("Clear",self.clear),]]
-        bbox.pack(side=Tix.TOP, fill=Tix.X)
+        bbox.pack(side=tkinter.tix.TOP, fill=tkinter.tix.X)
         for bt in bts:
-            bt.pack(side=Tix.LEFT, fill=Tix.X)
+            bt.pack(side=tkinter.tix.LEFT, fill=tkinter.tix.X)
         self.tlist = tlist
         self.patlist = []
         self.notebook = notebook
@@ -159,14 +159,14 @@ class PatternList(Tix.Frame):
         pass
 
     def save(self):
-        f = tkFileDialog.asksaveasfile(mode='w',filetypes=[('event pattern files', '.pats')],title="Save patterns as...",parent=self)
+        f = tkinter.filedialog.asksaveasfile(mode='w',filetypes=[('event pattern files', '.pats')],title="Save patterns as...",parent=self)
         if f:
             for p in self.patlist:
                 f.write('{}\n'.format(p))
             f.close()
                 
     def load(self):
-        f = tkFileDialog.askopenfile(mode='r',filetypes=[('event pattern files', '.pats')],title="Load patterns from...",parent=self)
+        f = tkinter.filedialog.askopenfile(mode='r',filetypes=[('event pattern files', '.pats')],title="Load patterns from...",parent=self)
         if f:
             for pat in f.readlines():
                 do_ask_pat(self.do_plus,pat)
@@ -175,15 +175,15 @@ class PatternList(Tix.Frame):
         pass
 
 def RunSample(w,evs):
-    top = Tix.Frame(w, relief=Tix.RAISED, bd=1)
+    top = tkinter.tix.Frame(w, relief=tkinter.tix.RAISED, bd=1)
     global the_ui
     the_ui = UI(w,top)
     notebook = EventNoteBook(top)
-    notebook.pack(side=Tix.LEFT, fill=Tix.BOTH,expand=1)
+    notebook.pack(side=tkinter.tix.LEFT, fill=tkinter.tix.BOTH,expand=1)
     notebook.new_sheet(evs)
     pats = PatternList(top,notebook)
-    pats.pack(expand=1, fill=Tix.BOTH, padx=10, side=Tix.LEFT)
-    top.pack(side=Tix.LEFT, fill=Tix.BOTH, expand=1)
+    pats.pack(expand=1, fill=tkinter.tix.BOTH, padx=10, side=tkinter.tix.LEFT)
+    top.pack(side=tkinter.tix.LEFT, fill=tkinter.tix.BOTH, expand=1)
     
 
 
@@ -232,7 +232,7 @@ def browsedir(tree, dir, evs):
 def main():
     import sys
     def usage():
-        print "usage: \n  {} <file>.iev ".format(sys.argv[0])
+        print("usage: \n  {} <file>.iev ".format(sys.argv[0]))
         sys.exit(1)
     if len(sys.argv) != 2:
         usage()
@@ -242,7 +242,7 @@ def main():
     try:
         f = open(fn,'r')
     except:
-        print "not found: %s" % fn
+        print("not found: %s" % fn)
         sys.exit(1)
 
     with iu.ErrorPrinter():
@@ -250,7 +250,7 @@ def main():
             s = f.read()
             evs = ev.parse(s)
     global tk
-    tk = Tix.Tk()
+    tk = tkinter.tix.Tk()
     RunSample(tk,evs)
     tk.mainloop()
 

--- a/ivy/ivy_fragment.py
+++ b/ivy/ivy_fragment.py
@@ -1,14 +1,14 @@
-import ivy_actions as ia
-import ivy_module as im
-import ivy_logic as il
-import ivy_utils as iu
-import logic_util as lu
-import ivy_logic_utils as ilu
-import ivy_theory as thy
+from . import ivy_actions as ia
+from . import ivy_module as im
+from . import ivy_logic as il
+from . import ivy_utils as iu
+from . import logic_util as lu
+from . import ivy_logic_utils as ilu
+from . import ivy_theory as thy
 from collections import defaultdict
 from tarjan import tarjan
 from itertools import chain
-from ivy_union_find import *
+from .ivy_union_find import *
 
 # Here we have rules for checking that VC's are in
 # a decidable fragment
@@ -380,25 +380,25 @@ def create_strat_map(assumes,asserts,macros):
 # Show a stratification graph. This is just for debugging.
 
 def show_strat_graph(m,a):
-    print 'nodes = {'
-    for x,y in m.iteritems():
+    print('nodes = {')
+    for x,y in m.items():
         z = find(y)
         if isinstance(x,tuple):
-            print '({},{}) : {} -> {}'.format(x[0],x[1],y,z)
+            print('({},{}) : {} -> {}'.format(x[0],x[1],y,z))
         else:
-            print '{} : {} -> {}'.format(x,y,z)
-    print '}'
-    print 'arcs = {'
+            print('{} : {} -> {}'.format(x,y,z))
+    print('}')
+    print('arcs = {')
     for arc in a:
-        print '(' + ','.join(str(x) for x in arc) + ')'
-    print '}'
+        print('(' + ','.join(str(x) for x in arc) + ')')
+    print('}')
     
         
 def report_feu_error(text):
     raise iu.IvyError(None,"The verification condition is not in the fragment FAU.\n\n{}".format(text))
 
 def get_node_sort(n):
-    for t,m in strat_map.iteritems():
+    for t,m in strat_map.items():
         if m is n:
             if isinstance(t,tuple):
                 return t[0].sort.dom[t[1]]
@@ -430,7 +430,7 @@ def report_interp_over_var(fmla,lineno,node):
     # First, try to fibd the offending variable in the strat map
 
     var_msg = ''
-    for v,n in strat_map.iteritems():
+    for v,n in strat_map.items():
         if n is node:
             if v in universally_quantified_variables:
                 lf = universally_quantified_variables[v]
@@ -451,9 +451,9 @@ def check_feu(assumes,asserts,macros):
     def vupair(p):
         return (var_uniq(p[0]),p[1])
 
-    assumes = map(vupair,assumes)
-    asserts = map(vupair,asserts)
-    macros = map(vupair,macros)
+    assumes = list(map(vupair,assumes))
+    asserts = list(map(vupair,asserts))
+    macros = list(map(vupair,macros))
 
     # Create the stratificaiton graph, as described above.
 

--- a/ivy/ivy_graph.py
+++ b/ivy/ivy_graph.py
@@ -4,16 +4,16 @@
 #TODO: get z3 references out of this file
 #TODO: the import *'s are creating conflicts
 
-from ivy_logic import Variable,EnumeratedSort,UninterpretedSort,all_symbols,Equals,And
-import ivy_logic as il
-import  ivy_logic_utils as ilu
+from .ivy_logic import Variable,EnumeratedSort,UninterpretedSort,all_symbols,Equals,And
+from . import ivy_logic as il
+from . import  ivy_logic_utils as ilu
 import functools
 from collections import defaultdict
-import concept as co
-import concept_interactive_session as cis
-from dot_layout import dot_layout
-from cy_elements import CyElements
-import ivy_utils as iu
+from . import concept as co
+from . import concept_interactive_session as cis
+from .dot_layout import dot_layout
+from .cy_elements import CyElements
+from . import ivy_utils as iu
 from copy import deepcopy
 
 # This creates a concept from a formula with free variables, using the
@@ -214,7 +214,7 @@ def render_concept_graph(widget):
 
     # treat custom_edge_info and custom_node_label
     custom = set()
-    for tag in a.keys():
+    for tag in list(a.keys()):
         if tag[0].startswith('custom_'):
             not_custom_tag = (tag[0][len('custom_'):],) + tag[1:]
             a[not_custom_tag] = a[tag]
@@ -484,7 +484,7 @@ class Graph(object):
     @property
     def relations(self):
         """ Returns all the concepts that need check-boxes """
-        return map(self.concept_from_id,self.relation_ids)
+        return list(map(self.concept_from_id,self.relation_ids))
 
     @property
     def node_ids(self):
@@ -494,7 +494,7 @@ class Graph(object):
     @property
     def nodes(self):
         """ Returns all the concepts that need check-boxes """
-        return map(self.concept_from_id,self.node_ids)
+        return list(map(self.concept_from_id,self.node_ids))
     
     def node_sort(self,node):
         return node.sorts[0]
@@ -632,8 +632,8 @@ class Graph(object):
 
     def show_checkboxes(self):
         def thing(n,c):
-            return (str(n) + ':' + str(set(x for x,y in c.iteritems() if y.value)))
-        return '\n'.join(thing(n,c) for n,c in self.edge_display_checkboxes.iteritems())
+            return (str(n) + ':' + str(set(x for x,y in c.items() if y.value)))
+        return '\n'.join(thing(n,c) for n,c in self.edge_display_checkboxes.items())
 
     def get_transitive_reduction(self):
         return [] # TODO: implement
@@ -776,7 +776,7 @@ class GraphStack(object):
         del self.redo_stack[:]
 
 def standard_graph(parent_state=None):
-    sorts = [s for s in il.sig.sorts.values() if il.is_first_order_sort(s)]
+    sorts = [s for s in list(il.sig.sorts.values()) if il.is_first_order_sort(s)]
     g = Graph(sorts,parent_state)
     return GraphStack(g)
     

--- a/ivy/ivy_graph_ui.py
+++ b/ivy/ivy_graph_ui.py
@@ -11,11 +11,11 @@ concept graphs """
 #TODO: the import *'s are creating conflicts
 import functools
 import string
-from ivy_graph import *
-import ivy_logic
-import ivy_logic_utils as lu
-import ivy_interp
-from ivy_utils import topological_sort
+from .ivy_graph import *
+from . import ivy_logic
+from . import ivy_logic_utils as lu
+from . import ivy_interp
+from .ivy_utils import topological_sort
 from collections import defaultdict
 
 repr = str
@@ -245,7 +245,7 @@ class GraphWidget(object):
         if hasattr(self,'fact_elems'):
             for fact in self.get_active_facts():
                 for elem in self.fact_elems[fact]:
-                    concepts = map(self.g.concept_from_id,elem)
+                    concepts = list(map(self.g.concept_from_id,elem))
                     if len(elem) == 1: # a node
                         self.select_node(concepts[0],True)
                     elif len(elem) == 3: # an edge
@@ -282,7 +282,7 @@ class GraphWidget(object):
             clauses, parent_state = p
             g.parent_state = parent_state
             g.set_state(ilu.and_clauses(parent_state.clauses,clauses),clear_constraints=True)
-            print "reverse: state = {}".format(g.state)
+            print("reverse: state = {}".format(g.state))
             # This is a HACK to support "diagram"
             g.reverse_result = (parent_state.clauses,clauses)
             self.update()
@@ -468,10 +468,10 @@ class GraphWidget(object):
     def materialize_from_selected(self,node):
         if hasattr(self,'mark'):
             sorts = tuple(self.g.node_sort(x) for x in [self.mark,node])
-            print "sorts: {}".format(sorts)
+            print("sorts: {}".format(sorts))
             for r in self.g.relations:
-                print "{}".format(r)
-                print ": {}".format(r.sorts)
+                print("{}".format(r))
+                print(": {}".format(r.sorts))
             rels = [r for r in self.g.relations if r.sorts == sorts]
             items = [self.g.concept_label(r) for r in rels]
             msg = "Materialize this relation from selected node:"

--- a/ivy/ivy_graphviz.py
+++ b/ivy/ivy_graphviz.py
@@ -78,10 +78,10 @@ def fix_parsed_graph(g):
     g.del_node('graph')
     g.del_node('node')
     g.del_node('edge')
-    for l in g.obj_dict['nodes'].values():
+    for l in list(g.obj_dict['nodes'].values()):
         for n in l:
             fix_attrs(n)
-    for l in g.obj_dict['edges'].values():
+    for l in list(g.obj_dict['edges'].values()):
         for e in l:
             fix_attrs(e)
     fix_attrs(g.obj_dict)
@@ -91,7 +91,7 @@ def fix_parsed_graph(g):
         fix_parsed_graph(sg)
 
 def fix_attrs(t):
-    t['attributes'] = dict((x,y.strip('"').replace('\\\n','')) for x,y in t['attributes'].iteritems())
+    t['attributes'] = dict((x,y.strip('"').replace('\\\n','')) for x,y in t['attributes'].items())
 
 # Work around pydot printing bug by putting quotes around labels
 
@@ -182,15 +182,15 @@ if __name__ == "__main__":
     g.add_node('4',label='bar')
     g.add_edge('3','4','e1')
     g.add_subgraph(name='cluster_2',nbunch=['3','4'])
-    print g
+    print(g)
     g.layout()
-    print g
-    print 'nodes: {}'.format(g.g.get_node_list())
+    print(g)
+    print('nodes: {}'.format(g.g.get_node_list()))
     for n in g.nodes():
-        print n
-    print g.get_edge('1','2','e1')
-    print g.get_node('1')
+        print(n)
+    print(g.get_edge('1','2','e1'))
+    print(g.get_node('1'))
     for sg in g.subgraphs():
-        print sg.graph_attr['bb']
+        print(sg.graph_attr['bb'])
 
 

--- a/ivy/ivy_graphviz.py
+++ b/ivy/ivy_graphviz.py
@@ -131,6 +131,7 @@ class AGraph(object):
         self.g.write(tmp_name)
         process = Popen(['dot','-Tdot',tmp_name], stdout=PIPE)
         txt,_ = process.communicate()
+        txt = txt.decode("utf-8")
         exit_code = process.wait()
 #        txt = self.g.create(prog=prog,format='dot')
         self.g =  pydot.dot_parser.parse_dot_data(txt)[0]

--- a/ivy/ivy_init.py
+++ b/ivy/ivy_init.py
@@ -13,18 +13,18 @@ if __name__ == "__main__":
 
 import pickle
 import string
-from ivy_compiler import IvyError, ivy_new, ivy_load_file
-from ivy_utils import Parameter, set_parameters
-import ivy_logic
-import proof as pf
-import ivy_utils as iu
-import ivy_module
+from .ivy_compiler import IvyError, ivy_new, ivy_load_file
+from .ivy_utils import Parameter, set_parameters
+from . import ivy_logic
+from . import proof as pf
+from . import ivy_utils as iu
+from . import ivy_module
 #import tactics_api as ta
 
 # mode = Parameter("mode",None)
 
 def usage():
-    print "usage: \n  {} <file>.[a2g,ivy,dfy]\n {} <file>.a2g <file.[ivy,dfy]> ".format(sys.argv[0],sys.argv[0])
+    print("usage: \n  {} <file>.[a2g,ivy,dfy]\n {} <file>.a2g <file.[ivy,dfy]> ".format(sys.argv[0],sys.argv[0]))
     sys.exit(1)
 
 def open_read(fn):
@@ -32,7 +32,7 @@ def open_read(fn):
         f = open(fn,'rU')
         return f
     except:
-        print "not found: %s" % fn
+        print("not found: %s" % fn)
         sys.exit(1)
 
 def read_params():
@@ -47,7 +47,7 @@ def read_params():
     try:
         set_parameters(ps)
     except IvyError as e:
-        print e
+        print(e)
         exit(1)
     sys.argv = sys.argv[0:1] + args
 
@@ -74,7 +74,7 @@ def source_file(fn,f,**kwargs):
     except IvyError as e:
         if not hasattr(e,'filename'):
             e.filename = fn
-        print str(e)
+        print(str(e))
         sys.exit(1)
 
 def ivy_init(**kwargs):

--- a/ivy/ivy_init.py
+++ b/ivy/ivy_init.py
@@ -39,7 +39,7 @@ def read_params():
     ps = dict()
     args = sys.argv[1:]
     while args and '=' in args[0]:
-        thing = string.split(args[0],'=')
+        thing = args[0].split('=')
         if len(thing) > 2:
             usage()
         ps[thing[0]] = thing[1]

--- a/ivy/ivy_interp.py
+++ b/ivy/ivy_interp.py
@@ -10,19 +10,20 @@ import z3
 import string
 from collections import defaultdict
 
-from ivy_logic import *
-from ivy_logic_utils import *
-from ivy_solver import unsat_core, clauses_imply, clauses_imply_formula, clauses_imply_list, clauses_model_to_clauses, clauses_model_to_diagram, get_model_clauses
-from ivy_transrel import compose_state_action, forward_interpolant, reverse_image, interpolant, \
+from .ivy_logic import *
+from .ivy_logic_utils import *
+from .ivy_solver import unsat_core, clauses_imply, clauses_imply_formula, clauses_imply_list, clauses_model_to_clauses, clauses_model_to_diagram, get_model_clauses
+from .ivy_transrel import compose_state_action, forward_interpolant, reverse_image, interpolant, \
     join_state, implies_state, ActionFailed, null_update, forward_image, reverse_interpolant_case, \
     is_skolem, interpolant_case, History, top_state, action_failure
-from ivy_actions import type_check,Action,RME
-import ivy_ast as ia
-import ivy_actions
-import ivy_transrel as tr
-import ivy_utils as iu
-import ivy_module as im
-import ivy_solver as islvr
+from .ivy_actions import type_check,Action,RME
+from . import ivy_ast as ia
+from . import ivy_actions
+from . import ivy_transrel as tr
+from . import ivy_utils as iu
+from . import ivy_module as im
+from . import ivy_solver as islvr
+from functools import reduce
   
 def type_check_list(domain,l):
     for x in l:
@@ -47,7 +48,7 @@ def module_type_check(self):
 def module_type_check_concepts(self):
     # tricky because we must consider concepts as relations
     relations = self.relations
-    self.relations = dict(relations.iteritems())
+    self.relations = dict(iter(relations.items()))
     self.relations.update((x.rep,len(x.args)) for x,y in self.concept_spaces)
     type_check_list(self,[y for x,y in self.concept_spaces])
     self.relations = relations
@@ -290,7 +291,7 @@ def reach_state(state,clauses=None):
     pre = join_unders(state.pred)
     if clauses == None:
         clauses = state.clauses
-    print "reach_state: clauses = {}".format(clauses)
+    print("reach_state: clauses = {}".format(clauses))
     axioms = state.domain.background_theory(state.in_scope)
     img = and_clauses(forward_image(pre,axioms,state.update),axioms,clauses)
     m = get_model_clauses(img)

--- a/ivy/ivy_isolate.py
+++ b/ivy/ivy_isolate.py
@@ -2,20 +2,20 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_logic
-import ivy_dafny_compiler as dc
-import ivy_solver as slv
-import ivy_logic_utils as lu
+from . import ivy_logic
+from . import ivy_dafny_compiler as dc
+from . import ivy_solver as slv
+from . import ivy_logic_utils as lu
 import string
-import ivy_ast
-import ivy_utils as iu
-import ivy_actions as ia
-import ivy_alpha
-import ivy_module as im
-import ivy_theory as ith
-from ivy_ast import ASTContext
+from . import ivy_ast
+from . import ivy_utils as iu
+from . import ivy_actions as ia
+from . import ivy_alpha
+from . import ivy_module as im
+from . import ivy_theory as ith
+from .ivy_ast import ASTContext
 from collections import defaultdict
-import ivy_printer
+from . import ivy_printer
 
 show_compiled = iu.BooleanParameter("show_compiled",False)
 cone_of_influence = iu.BooleanParameter("coi",True)
@@ -241,7 +241,7 @@ def strip_action(ast,strip_map,strip_binding,is_init=False,init_params=[]):
                         raise iu.IvyError(ast,"assignment may be interfering")
     if isinstance(ast,ia.AssignAction) and len(init_params) > 0:
         lhs = ast.args[0]
-        xtra_bindings = zip(lhs.args[len(strip_binding):],init_params)
+        xtra_bindings = list(zip(lhs.args[len(strip_binding):],init_params))
         if any(not ivy_logic.is_variable(x) for x,y in xtra_bindings):
             raise iu.IvyError(ast,"assignment may be interfering")
         strip_binding = strip_binding.copy()
@@ -350,7 +350,7 @@ def strip_isolate(mod,isolate,impl_mixins,all_after_inits,extra_strip):
                 if a.rep in ivy_logic.sig.symbols:
                     raise iu.IvyError(a,"isolate parameter redefines {}",a.rep)
             strip_map[name] = [a.rep for a in atom.args]
-    for ms in impl_mixins.values():
+    for ms in list(impl_mixins.values()):
         for m in ms:
             if isinstance(m,ivy_ast.MixinImplementDef):
                 strip_params = strip_map_lookup(canon_act(m.mixer()),strip_map)
@@ -360,7 +360,7 @@ def strip_isolate(mod,isolate,impl_mixins,all_after_inits,extra_strip):
 #        strip_map[imp.imported()] = [a.rep for a in isolate.params()]
     # strip the actions
     new_actions = {}
-    for name,action in mod.actions.iteritems():
+    for name,action in mod.actions.items():
         strip_params = strip_map_lookup(canon_act(name),strip_map,with_dot=False)
         orig_name = name[4:] if name.startswith('ext:') else name
         is_init=(orig_name in all_after_inits)
@@ -370,7 +370,7 @@ def strip_isolate(mod,isolate,impl_mixins,all_after_inits,extra_strip):
                 init_params = strip_params[len(action.formal_params):]
             else:
                 raise iu.IvyError(action,"cannot strip isolate parameters from {}".format(name))
-        strip_binding = dict(zip(action.formal_params,strip_params))
+        strip_binding = dict(list(zip(action.formal_params,strip_params)))
 #        if isinstance(action,ia.NativeAction) and len(strip_params) != num_isolate_params:
 #            raise iu.IvyError(None,'foreign function {} may be interfering'.format(name))
         new_action = strip_action(action,strip_map,strip_binding,is_init=is_init,init_params=init_params)
@@ -391,7 +391,7 @@ def strip_isolate(mod,isolate,impl_mixins,all_after_inits,extra_strip):
 
     # strip the signature
     new_symbols = {}
-    for name,sym in ivy_logic.sig.symbols.iteritems():
+    for name,sym in ivy_logic.sig.symbols.items():
         if sym not in im.module.sig.constructors:
             strip_params = strip_map_lookup(name,strip_map)
             if strip_params:
@@ -550,7 +550,7 @@ def find_references(mod,syms,new_actions):
     for x in mod.labeled_axioms+mod.labeled_props+mod.labeled_inits+mod.labeled_conjs+mod.definitions:
         if syms.intersection(lu.used_symbols_ast(x.formula)):
             refs.add(x.lineno)
-    for x in new_actions.values():
+    for x in list(new_actions.values()):
         if syms.intersection(lu.used_symbols_ast(x)):
             refs.add(x.lineno)
     return refs
@@ -569,7 +569,7 @@ def check_interference(mod,new_actions,summarized_actions,impl_mixins,check_term
     callouts = dict()  # these are triples (midcalls,headcalls,tailcalls,bothcalls)
     for actname in new_actions:
         get_callouts(mod,new_actions,summarized_actions,actname,callouts)
-    for actname,action in new_actions.iteritems():
+    for actname,action in new_actions.items():
         if actname not in summarized_actions:
             for called_name in action.iter_calls():
                 called_name = canon_act(called_name)
@@ -642,7 +642,7 @@ def get_prop_dependencies(mod):
     """ get a list of pairs (p,ds) where p is a property ds is a list
     of objects its proof depends on """
     depmap = defaultdict(list)
-    for iso in mod.isolates.values():
+    for iso in list(mod.isolates.values()):
         for v in iso.verified():
             depmap[v.rep].extend(w.rep for w in iso.verified()+iso.present())
     objs = set()
@@ -650,7 +650,7 @@ def get_prop_dependencies(mod):
         if ax.label:
             for n in ancestors(ax.label.rep):
                 objs.add(n)
-    for itps in mod.interps.values():
+    for itps in list(mod.interps.values()):
         for itp in itps:
             if itp.label:
                 for n in ancestors(itp.label.rep):
@@ -670,7 +670,7 @@ def set_privates_prefer(mod,isolate,preferred):
     mod.privates = set(mod.privates)
     if 'this' not in verified and suff in mod.hierarchy and preferred in mod.hierarchy:
         mod.privates.add(suff)
-    for n,l in mod.hierarchy.iteritems():
+    for n,l in mod.hierarchy.items():
         if n not in verified:
             if suff in l and preferred in l:
                 mod.privates.add(iu.compose_names(n,suff))
@@ -692,7 +692,7 @@ def set_privates(mod,isolate,suff=None):
     mod.privates = set(mod.privates)
     if suff in mod.hierarchy:
         mod.privates.add(suff)
-    for n,l in mod.hierarchy.iteritems():
+    for n,l in mod.hierarchy.items():
         nsuff = get_private_from_attributes(mod,n,suff)
         if nsuff in l:
             mod.privates.add(iu.compose_names(n,nsuff))
@@ -705,7 +705,7 @@ def set_privates(mod,isolate,suff=None):
                 mod.privates.add(p)
     global vprivates
     vprivates = set()
-    for isol in mod.isolates.values():
+    for isol in list(mod.isolates.values()):
         for v in isol.verified():
             vprivates.add(v.rep)
             
@@ -729,7 +729,7 @@ def get_props_proved_in_isolate(mod,isolate):
         set_privates(mod,isolate,'impl')
         verified,present = get_isolate_info(mod,isolate,'impl')
         if not iu.version_le(iu.get_string_version(),"1.6"):
-            for other_iso in mod.isolates.values():
+            for other_iso in list(mod.isolates.values()):
                 if other_iso is not isolate:
                     for other_verified in other_iso.verified():
                         ovn = other_verified.relname
@@ -782,7 +782,7 @@ def get_isolate_info(mod,isolate,kind,extra_with=[]):
     present.update(xtra)
 
     vp = set()
-    for isol in mod.isolates.values():
+    for isol in list(mod.isolates.values()):
         for v in isol.verified():
             vp.add(v.rep)
     for name in mod.attributes:
@@ -870,7 +870,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
 
     impl_mixins = defaultdict(list)
     # delegate all the stub actions to their implementations
-    for actname,ms in mod.mixins.iteritems():
+    for actname,ms in mod.mixins.items():
         implements = [m for m in ms if isinstance(m,ivy_ast.MixinImplementDef)]
         impl_mixins[actname].extend(implements)
         before_after = [m for m in ms if not isinstance(m,ivy_ast.MixinImplementDef)]
@@ -934,7 +934,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
                                   else []))
 
     summarized_actions = set()
-    for actname,action in mod.actions.iteritems():
+    for actname,action in mod.actions.items():
         ver = vstartswith_eq_some(actname,verified,mod)
         pre = startswith_eq_some(actname,present,mod)
         if pre: 
@@ -1007,7 +1007,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
     explicit_exports = set(exported)
 
     with_effects = set()
-    for actname,action in mod.actions.iteritems():
+    for actname,action in mod.actions.items():
         if not startswith_eq_some(actname,present,mod):
             for subaction in action.iter_subactions():
                 if isinstance(subaction,ia.CallAction):
@@ -1120,7 +1120,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
     # Get rid of the inaccessible actions
 
     cone = get_mod_cone(mod,actions=new_actions,roots=exported,after_inits=after_inits)        
-    new_actions = dict((x,y) for x,y in new_actions.iteritems() if x in cone)
+    new_actions = dict((x,y) for x,y in new_actions.items() if x in cone)
     mod.isolate_info.implementations = [(impl,actname,action) for impl,actname,action in mod.isolate_info.implementations
                                        if actname in new_actions or 'ext:'+actname in new_actions]
     mod.isolate_info.monitors = [(mixer,mixee,action) for mixer,mixee,action in mod.isolate_info.monitors
@@ -1134,8 +1134,8 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
     asts = []
     for x in [mod.labeled_axioms,mod.labeled_props,mod.labeled_inits,mod.labeled_conjs]:
         asts += [y.formula for y in x if not isinstance(y.formula,ivy_ast.SchemaBody)]
-    asts += [action for action in new_actions.values()]
-    for a in mod.actions.values():
+    asts += [action for action in list(new_actions.values())]
+    for a in list(mod.actions.values()):
         asts.extend(a.formal_params)
         asts.extend(a.formal_returns)
     for tmp in mod.natives:
@@ -1159,7 +1159,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
             for x in lu.used_symbols_ast(a.formula):
                 if x in all_syms and not ivy_logic.is_interpreted_symbol(x) and x not in determined:
                     raise iu.IvyError(a,"relevant axiom {} not enforced (uses symbol {})".format(pname(a),x))
-        for actname,action in mod.actions.iteritems():
+        for actname,action in mod.actions.items():
             if startswith_eq_some(actname,present,mod):
                 for c in action.iter_calls():
                     imp = implementation_map.get(c,c)
@@ -1206,10 +1206,10 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
     asts = []
     for x in [mod.labeled_axioms,mod.labeled_props,mod.labeled_inits,mod.labeled_conjs,mod.definitions]:
         asts.extend(y.formula for y in x if not isinstance(y.formula,ivy_ast.SchemaBody))
-    asts.extend(action for action in mod.actions.values())
+    asts.extend(action for action in list(mod.actions.values()))
     if opt_keep_destructors.get():
         asts.extend(mod.params) # if compiling, keep all of the parameters
-    for a in mod.actions.values():
+    for a in list(mod.actions.values()):
         asts.extend(a.formal_params)
         asts.extend(a.formal_returns)
     for tmp in mod.natives:
@@ -1239,7 +1239,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
     # check that any properties have dependencies present
 
     if enforce_axioms.get():
-        all_syms_norm = map(ivy_logic.normalize_symbol,all_syms)
+        all_syms_norm = list(map(ivy_logic.normalize_symbol,all_syms))
         for p,ds in prop_deps:
             for d in ds:
                 if not startswith_eq_some(d,present,mod):
@@ -1304,7 +1304,7 @@ def isolate_component(mod,isolate_name,extra_with=[],extra_strip=None,after_init
     # check that native code does not occur in an untrusted isolate
 
     if type(isolate) == ivy_ast.IsolateDef and isolate_mode.get() != 'test':
-        for action in mod.actions.values():
+        for action in list(mod.actions.values()):
             if isinstance(action,ia.NativeAction):
                 raise iu.IvyError(action,'trusted code used in untrusted isolate')
         for ldf in mod.definitions:
@@ -1351,7 +1351,7 @@ class SortOrder(object):
 
 def get_mixin_order(iso,mod):
     arcs = [(rdf.args[0].relname,rdf.args[1].relname) for rdf in mod.mixord]
-    actions = mod.mixins.keys()
+    actions = list(mod.mixins.keys())
     for action in actions:
         mixins = mod.mixins[action]
         implements = [m for m in mixins if isinstance(m,ivy_ast.MixinImplementDef)]
@@ -1448,7 +1448,7 @@ def fix_initializers(mod,after_inits):
 def set_up_implementation_map(mod):
     global implementation_map
     implementation_map = {}
-    for actname,ms in mod.mixins.iteritems():
+    for actname,ms in mod.mixins.items():
         implements = [m for m in ms if isinstance(m,ivy_ast.MixinImplementDef)]
         for m in implements:
             implementation_map[m.mixee()] = m.mixer()
@@ -1480,14 +1480,14 @@ def apply_present_conjectures(isol,mod):
     cg = mod.call_graph()  # TODO: cg should be cached
     myexports = get_isolate_exports(mod,cg,isol)
     for actname in myexports:
-        assumes = map(conj_to_assume,conjs)
+        assumes = list(map(conj_to_assume,conjs))
         brackets.append((actname,assumes,[]))
     posts = defaultdict(list)
     for conj in conjs:
         for actname in mod.conj_actions[conj.label.rep]:
             if actname not in myexports:
                 posts[actname].append(conj_to_assume(conj))
-    for actname,assumes in posts.iteritems():
+    for actname,assumes in posts.items():
         brackets.append((actname,[],assumes))
     return brackets
 
@@ -1516,7 +1516,7 @@ def create_isolate(iso,mod = None,**kwargs):
 
         # check all mixin declarations
 
-        for name,mixins in mod.mixins.iteritems():
+        for name,mixins in mod.mixins.items():
             for mixin in mixins:
                 with ASTContext(mixin):
                     action1,action2 = (lookup_action(mixin,mod,a.relname) for a in mixin.args)
@@ -1594,7 +1594,7 @@ def create_isolate(iso,mod = None,**kwargs):
             mod.imports = newimps
 
         mixers = set()
-        for ms in mod.mixins.values():
+        for ms in list(mod.mixins.values()):
             for m in ms:
                 mixers.add(m.mixer())
 
@@ -1613,7 +1613,7 @@ def create_isolate(iso,mod = None,**kwargs):
             # apply all the mixins in no particular order
             mod.isolate_info = im.IsolateInfo()
             implemented = set()
-            for name,mixins in mod.mixins.iteritems():
+            for name,mixins in mod.mixins.items():
                 for mixin in mixins:
                     action1,action2 = (lookup_action(mixin,mod,a.relname) for a in mixin.args)
                     mixed_name = mixin.args[1].relname
@@ -1628,7 +1628,7 @@ def create_isolate(iso,mod = None,**kwargs):
                     else:
                         mod.isolate_info.monitors.append(triple)
                     implemented.add(mixin.mixer())
-            for actname,action in mod.actions.iteritems():
+            for actname,action in mod.actions.items():
                 if actname not in implemented:
                     mod.isolate_info.implementations.append((actname,actname,action))
             # find the globally exported actions (all if none specified, for compat)
@@ -1735,7 +1735,7 @@ def check_isolate_completeness(mod = None):
     global implementation_map
     implementation_map = {}
     impl_mixins = defaultdict(list)
-    for actname,ms in mod.mixins.iteritems():
+    for actname,ms in mod.mixins.items():
         implements = [m for m in ms if isinstance(m,ivy_ast.MixinImplementDef)]
         impl_mixins[actname].extend(implements)
         for m in implements:
@@ -1744,7 +1744,7 @@ def check_isolate_completeness(mod = None):
                     raise IvyError(m,'action {} not defined'.format(foo))
             implementation_map[m.mixee()] = m.mixer()
     
-    for iso_name,isolate in mod.isolates.iteritems():
+    for iso_name,isolate in mod.isolates.items():
         verified,present = get_isolate_info(mod,isolate,'impl')
         save_privates = mod.privates
         set_privates(mod,isolate)
@@ -1775,7 +1775,7 @@ def check_isolate_completeness(mod = None):
         if lbl:
             trusted.add(lbl.rep)
             
-    for actname,action in mod.actions.iteritems():
+    for actname,action in mod.actions.items():
         if startswith_eq_some(actname,trusted,mod):
             continue
         for callee in action.iter_calls():
@@ -1814,20 +1814,20 @@ def check_isolate_completeness(mod = None):
         for x,y,z in missing:
             mixer = y.mixer() if isinstance(y,ivy_ast.MixinDef) else y
             mixee = y.mixee() if isinstance(y,ivy_ast.MixinDef) else y
-            print iu.IvyError(find_some_assertion(mod,mixer,kind=z),"assertion is not checked")
+            print(iu.IvyError(find_some_assertion(mod,mixer,kind=z),"assertion is not checked"))
             if mixee != mixer:
-                print iu.IvyError(mod.actions[mixee],"...in action {}".format(mixee))
+                print(iu.IvyError(mod.actions[mixee],"...in action {}".format(mixee)))
             if x == "external":
-                print "error: ...when called from the environment"
+                print("error: ...when called from the environment")
             else:
-                print iu.IvyError(find_some_call(mod,x,mixee),"...when called from {}".format(x))
+                print(iu.IvyError(find_some_call(mod,x,mixee),"...when called from {}".format(x)))
     
     done = set()
     for prop in mod.labeled_props:
         if prop.label:
             label = prop.label.relname
             if label not in checked_props and label not in done:
-                print iu.IvyError(prop,"property {} not checked".format(label))
+                print(iu.IvyError(prop,"property {} not checked".format(label)))
                 missing.append((label,None,None))
                 done.add(label)
         
@@ -1851,7 +1851,7 @@ def iter_isolate(mod,iso,fun,verified=True,present=True):
     # Record all the isolate roots, so we can detect sub-isolates
 
     vp = set()
-    for isol in mod.isolates.values():
+    for isol in list(mod.isolates.values()):
         for v in isol.verified():
             vp.add(v.rep)
             
@@ -1918,7 +1918,7 @@ def get_isolate_exports(mod,cg,iso):
 
 def get_isolate_map(mod,verified=True,present=True):
     res = defaultdict(list)
-    for ison,isol in mod.isolates.iteritems():
+    for ison,isol in mod.isolates.items():
         def fun(name):
             res[name].append(ison)
         iter_isolate(mod,isol,fun,verified,present)

--- a/ivy/ivy_lexer.py
+++ b/ivy/ivy_lexer.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 import ply.lex as lex
-import ivy_utils as iu
+from . import ivy_utils as iu
 
 tokens = (
    'COMMA',
@@ -217,7 +217,7 @@ class TokenErrorNode(object):
 
 def t_error(t):
     raise iu.IvyError(TokenErrorNode(t),"illegal character '{}'".format(t.value[0]))
-    print "Illegal character '%s'" % t.value[0]
+    print("Illegal character '%s'" % t.value[0])
 
 lexer = lex.lex(errorlog=lex.NullLogger())
 

--- a/ivy/ivy_libs.py
+++ b/ivy/ivy_libs.py
@@ -43,7 +43,7 @@ def main():
     prefix = sys.argv[3] if len(sys.argv) >= 4 else default_prefix
     libdir = [os.path.join(prefix,sys.argv[4])] if len(sys.argv) >= 5 else []
 
-    print 'Adding library {} at prefix {}.'.format(name,prefix)
+    print('Adding library {} at prefix {}.'.format(name,prefix))
 
     specfilename = os.path.join(libpath,'specs')
 

--- a/ivy/ivy_logic.py
+++ b/ivy/ivy_logic.py
@@ -62,15 +62,15 @@ args and not applied symbol.
 
 """
 
-from ivy_utils import flatten, IvyError
-import ivy_utils as iu
-import logic as lg
-import logic_util as lu
-from logic import And,Or,Not,Globally,Eventually,Implies,Iff,Ite,ForAll,Exists,Lambda,NamedBinder
-from type_inference import concretize_sorts, concretize_terms
+from .ivy_utils import flatten, IvyError
+from . import ivy_utils as iu
+from . import logic as lg
+from . import logic_util as lu
+from .logic import And,Or,Not,Globally,Eventually,Implies,Iff,Ite,ForAll,Exists,Lambda,NamedBinder
+from .type_inference import concretize_sorts, concretize_terms
 from collections import defaultdict
 from itertools import chain
-import ivy_smtlib
+from . import ivy_smtlib
 
 allow_unsorted = False
 repr = str
@@ -450,7 +450,7 @@ def is_segregated(fmla):
     vs = lu.used_variables(fmla)
     apps = list(t for t in subterms(fmla) if isinstance(t,lg.Apply) and lu.used_variables(t))
     byname = iu.partition(apps,lambda self:self.func.name)
-    for name,terms in byname.iteritems():
+    for name,terms in byname.items():
         pat = seg_var_pat(terms[0])
         pvs = set(x for x in pat if x != None)
         if pvs != vs:
@@ -510,7 +510,7 @@ def symbols_over_universals(fmlas):
         try:
             symbols_over_universals_rec(fmla,syms,True,set())
         except Exception as foo:
-            print fmla
+            print(fmla)
             raise foo
     return syms
 
@@ -839,7 +839,7 @@ def is_topsort(sort):
 def sortify(ast):
     args = [sortify(arg) for arg in ast.args]
     if (isinstance(ast,App)) and isinstance(ast.rep.sort,lg.TopSort):
-        return apply(find_symbol(ast.rep),args)
+        return find_symbol(ast.rep)(*args)
     return ast.clone(args)
 
 # Signatures
@@ -875,7 +875,7 @@ class Sig(object):
         res.default_numeric_sort = self.default_numeric_sort
         return res
     def all_symbols(self):
-        for name,sym in self.symbols.iteritems():
+        for name,sym in self.symbols.items():
             if isinstance(sym.sort,UnionSort):
                 for sort in sym.sort.sorts:
                     yield Symbol(sym.name,sort)
@@ -1147,7 +1147,7 @@ def sort_infer_list(terms,sorts=None,no_error=False,unsorted_var_names=()):
     return res
 
 def sorts():
-    return [s for n,s in sig.sorts.iteritems()]
+    return [s for n,s in sig.sorts.items()]
 
 def is_ui_sort(s):
     return type(s) is lg.UninterpretedSort
@@ -1407,15 +1407,15 @@ def canonize_sort(sort):
     return sort
 
 def sort_refinement():
-    return dict((s,canonize_sort(s)) for s in sig.sorts.values() if not is_canonical_sort(s))
+    return dict((s,canonize_sort(s)) for s in list(sig.sorts.values()) if not is_canonical_sort(s))
 
 # This returns only the *canonical* uninterpreted sorts
 
 def uninterpreted_sorts():
-    return [s for s in sig.sorts.values() if isinstance(s,UninterpretedSort) and s.name not in sig.interp]
+    return [s for s in list(sig.sorts.values()) if isinstance(s,UninterpretedSort) and s.name not in sig.interp]
 
 def interpreted_sorts():
-    return [s for s in sig.sorts.values() if is_interpreted_sort(s)]
+    return [s for s in list(sig.sorts.values()) if is_interpreted_sort(s)]
 
 def is_uninterpreted_sort(s):
     s = canonize_sort(s)
@@ -1462,14 +1462,14 @@ def typed_sym_to_str(sym):
 
 def sig_to_str(self):
     res = ''
-    for name,sort in self.sorts.iteritems():
+    for name,sort in self.sorts.items():
         if name == 'bool':
             continue
         res += 'type {}'.format(name)
         if not isinstance(sort,UninterpretedSort):
             res += ' = {}'.format(sort)
         res += '\n'
-    for name,sym in self.symbols.iteritems():
+    for name,sym in self.symbols.items():
         sorts = sym.sort.sorts if isinstance(sym.sort,UnionSort) else [sym.sort]
         for sort in sorts:
             res +=  'relation ' if sort.is_relational() else 'function ' if sort.dom else 'individual '
@@ -1489,12 +1489,12 @@ if __name__ == '__main__':
     n = Predicate('n', 2)
     is_ = Predicate('is', 1)
 
-    print [[~n(V1, V2), ~n(x, V1), n(x, y), is_(V2), is_(V1)],
+    print([[~n(V1, V2), ~n(x, V1), n(x, y), is_(V2), is_(V1)],
            [V1 == x,V1 != x],
            [y == x, y != x],
            [V1 == V2, V1 != V2],
            [x == V2, x != V2],
-    ]
+    ])
 
 def is_true(ast):
     return isinstance(ast,And) and not ast.args
@@ -1557,7 +1557,7 @@ CaptureError = lu.CaptureError
 
 def lambda_apply(self,args):
     assert len(args) == len(self.variables)
-    return lu.substitute(self.body,dict(zip(self.variables,args)))
+    return lu.substitute(self.body,dict(list(zip(self.variables,args))))
 
 lg.Lambda.__call__ = lambda self,*args: lambda_apply(self,args)
 
@@ -1590,8 +1590,8 @@ class VariableUniqifier(object):
             # save the old bindings
             obs = [(v,vmap[v]) for v in fmla.variables if v in vmap]
             newvars = tuple(Variable(self.rn(v.name),v.sort) for v in fmla.variables)
-            vmap.update(zip(fmla.variables,newvars))
-            self.invmap.update(zip(newvars,fmla.variables))
+            vmap.update(list(zip(fmla.variables,newvars)))
+            self.invmap.update(list(zip(newvars,fmla.variables)))
             try:
                 res = fmla.clone_binder(newvars,self.rec(fmla.body,vmap))
             except TypeError:
@@ -1651,7 +1651,7 @@ def alpha_rename(nmap,fmla):
 def normalize_ops(fmla):
     """Convert conjunctions and disjunctions to binary ops and quantifiers
     to single-variable quantifiers. """
-    args = map(normalize_ops,fmla.args)
+    args = list(map(normalize_ops,fmla.args))
     def mkbin(op,first,rest):
         if len(rest) == 0:
             return first

--- a/ivy/ivy_logic_parser.py
+++ b/ivy/ivy_logic_parser.py
@@ -2,9 +2,9 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 # This file contains parser rules for first-order formulas
-from ivy_ast import *
-import ivy_logic_utils
-import ivy_utils as iu
+from .ivy_ast import *
+from . import ivy_logic_utils
+from . import ivy_utils as iu
 
 def get_lineno(p,n):
     return iu.Location(iu.filename,p.lineno(n))

--- a/ivy/ivy_logic_parser_gen.py
+++ b/ivy/ivy_logic_parser_gen.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_lexer import *
+from .ivy_lexer import *
 import ply.yacc as yacc
 
 # Parser for formulas
@@ -26,7 +26,7 @@ precedence = (
     ('left', 'DOT'),
 )
 
-from ivy_logic_parser import *
+from .ivy_logic_parser import *
 
 def p_error(token):
     raise LogicParseError(token,"syntax error")

--- a/ivy/ivy_logic_utils.py
+++ b/ivy/ivy_logic_utils.py
@@ -14,17 +14,17 @@
 
 """
 
-from ivy_utils import *
-from ivy_logic import *
+from .ivy_utils import *
+from .ivy_logic import *
 import string
-from ivy_lexer import *
+from .ivy_lexer import *
 import ply.yacc as yacc
 from functools import partial
-import ivy_logic
+from . import ivy_logic
 from itertools import chain
-from ivy_logic_parser_gen import formula_parser,term_parser
+from .ivy_logic_parser_gen import formula_parser,term_parser
 from collections import defaultdict
-import logic_util
+from . import logic_util
 
 
 class LogicParseError(Exception):
@@ -166,7 +166,7 @@ def substitute_ast(ast,subs):
         return subs.get(ast.rep,ast)
     if is_quantifier(ast):
         bounds = set(x.name for x in quantifier_vars(ast))
-        subs = dict((x,y) for x,y in subs.iteritems() if x not in bounds)
+        subs = dict((x,y) for x,y in subs.items() if x not in bounds)
     return ast.clone(substitute_ast(x,subs) for x in ast.args)
 
 def substitute_constants_ast(ast,subs):
@@ -316,10 +316,10 @@ def resort_ast(ast,subs):
 
 
 def resort_sig(subs):
-    ivy_logic.sig.symbols = dict((n,resort_symbol(s,subs)) for n,s in ivy_logic.sig.symbols.iteritems())
+    ivy_logic.sig.symbols = dict((n,resort_symbol(s,subs)) for n,s in ivy_logic.sig.symbols.items())
     refd = set(s.name for s in subs)
-    ivy_logic.sig.sorts = dict((n,resort_sort(s,subs)) for n,s in ivy_logic.sig.sorts.iteritems() if n not in refd)
-    ivy_logic.sig.interp = dict((n,s) for n,s in ivy_logic.sig.interp.iteritems() if n not in refd)
+    ivy_logic.sig.sorts = dict((n,resort_sort(s,subs)) for n,s in ivy_logic.sig.sorts.items() if n not in refd)
+    ivy_logic.sig.interp = dict((n,s) for n,s in ivy_logic.sig.interp.items() if n not in refd)
 
 
 # aliases for backward compat
@@ -730,8 +730,8 @@ def tseitin_encoding(f):
     global tseitin_context
     tc = tseitin_context
     if not tc:
-        print f
-        print type(f)
+        print(f)
+        print(type(f))
         raise ValueError()
     f = expand_abbrevs(f)
     if isinstance(f,And):
@@ -1225,19 +1225,19 @@ def or_clauses_int(rn,args):
                 defidx[s] = d
             else:
                 defidx[s] = Definition(d.args[0],Ite(v,d.args[1],defidx[s].args[1]))
-    defs = [d for n,d in defidx.iteritems()] # TODO: hash traversal dependency
+    defs = [d for n,d in defidx.items()] # TODO: hash traversal dependency
     res = Clauses(fmlas,defs)
     #    print "or_clauses_int res = {}".format(res)
     return res,vs,args
 
 def debug_clauses_list(cl):
     for clauses in cl:
-        print "definitions:"
+        print("definitions:")
         for df in clauses.defs:
-            print df
-        print "fmlas:"
+            print(df)
+        print("fmlas:")
         for fmla in clauses.fmlas:
-            print ivy_logic.close_formula(fmla)
+            print(ivy_logic.close_formula(fmla))
 
 def ite_clauses_int(rn,cond,args):
     assert len(args) == 2
@@ -1261,7 +1261,7 @@ def ite_clauses_int(rn,cond,args):
             defidx[s] = d
         else:
             defidx[s] = Definition(d.args[0],simp_ite(v,defidx[s].args[1],d.args[1]))
-    defs = [d for n,d in defidx.iteritems()] + [Definition(v,cond)] # TODO: hash traversal dependency
+    defs = [d for n,d in defidx.items()] + [Definition(v,cond)] # TODO: hash traversal dependency
     annot = None if a0 is None or a1 is None else a0.ite(v,a1)
     res = Clauses(fmlas,defs,annot)
     # print "ite_clauses_int res:"
@@ -1348,7 +1348,7 @@ def exists_quant_clauses_map(syms,clauses):
         if not eqcm_upd(lhs,rhs,symset,map2):
             if not eqcm_upd(rhs,lhs,symset,map2):
                 defs.append(df)
-    for v,w in map2.iteritems():
+    for v,w in map2.items():
         for x in w:
             map1[x] = v
     clauses = Clauses(clauses.fmlas,defs)
@@ -1499,7 +1499,7 @@ def witness_ast(pos,vs,witnesses,fmla):
 
 
 def reskolemize_clauses(clauses, skolemizer):
-    print clauses
+    print(clauses)
     cs = [c for c in used_constants_clauses(clauses) if '__' in c.rep]
 #    print "reskolemize_clauses c = {}".format(cs)
     sksubs = dict((c,skolemizer(Variable(c.rep,c.sort))) for c in cs)

--- a/ivy/ivy_mc.py
+++ b/ivy/ivy_mc.py
@@ -2,18 +2,18 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_module as im
-import ivy_actions as ia
-import ivy_logic as il
-import ivy_transrel as tr
-import ivy_logic_utils as ilu
-import ivy_utils as iu
-import ivy_art as art
-import ivy_interp as itp
-import ivy_theory as thy
-import ivy_ast
-import ivy_proof
-import ivy_trace
+from . import ivy_module as im
+from . import ivy_actions as ia
+from . import ivy_logic as il
+from . import ivy_transrel as tr
+from . import ivy_logic_utils as ilu
+from . import ivy_utils as iu
+from . import ivy_art as art
+from . import ivy_interp as itp
+from . import ivy_theory as thy
+from . import ivy_ast
+from . import ivy_proof
+from . import ivy_trace
 
 import tempfile
 import subprocess
@@ -82,7 +82,7 @@ class Aiger(object):
         return 2*(arg/2) + (1 - arg%2)
     
     def orl(self,*args):
-        return self.notl(self.andl(*map(self.notl,args)))
+        return self.notl(self.andl(*list(map(self.notl,args))))
 
     def ite(self,x,y,z):
         return self.orl(self.andl(x,y),self.andl(self.notl(x),z))
@@ -107,7 +107,7 @@ class Aiger(object):
                     assert getdef is not None, "no definition for {} in aiger output".format(sym)
                     return getdef(sym)
             else:
-                args = map(recur,expr.args)
+                args = list(map(recur,expr.args))
                 if isinstance(expr,il.And):
                     return self.andl(*args)
                 if isinstance(expr,il.Or):
@@ -170,7 +170,7 @@ class Aiger(object):
         return self.sym_vals(self.inputs)
 
     def show_state(self):
-        print 'state: {}'.format(self.latch_vals())
+        print('state: {}'.format(self.latch_vals()))
         
     def reset(self):
         self.state = dict((self.map[x],'0') for x in self.latches)
@@ -194,24 +194,24 @@ class Aiger(object):
 #            print 'gate {}: {}'.format(out,res)
 #        print 'outputs: {}'.format(''.join(self.getin(self.values[x]) for x in self.outputs))
 
-    def next(self):
+    def __next__(self):
         for lt in self.latches:
             self.state[self.map[lt]] = self.getin(self.values[lt])
 #        self.show_state()
 
 
     def debug(self):
-        print 'inputs: {}'.format([str(x) for x in self.inputs])
-        print 'latches: {}'.format([str(x) for x in self.latches])
-        print 'outputs: {}'.format([str(x) for x in self.outputs])
-        print 'map:'
-        for x,y in self.map.iteritems():
-            print '{} = {}'.format(x,y)
-        print 'values:'
-        for x,y in self.values.iteritems():
-            print '{} = {}'.format(x,y)
-        print 'self:'
-        print self
+        print('inputs: {}'.format([str(x) for x in self.inputs]))
+        print('latches: {}'.format([str(x) for x in self.latches]))
+        print('outputs: {}'.format([str(x) for x in self.outputs]))
+        print('map:')
+        for x,y in self.map.items():
+            print('{} = {}'.format(x,y))
+        print('values:')
+        for x,y in self.values.items():
+            print('{} = {}'.format(x,y))
+        print('self:')
+        print(self)
 
         
             
@@ -279,7 +279,7 @@ class Encoder(object):
         return [self.sub.false()]
 
     def lit(self,sym):
-        return map(self.sub.lit,self.encoding[sym])
+        return list(map(self.sub.lit,self.encoding[sym]))
 
     def define(self,sym,val):
         vs = encode_vars([sym],self.encoding)
@@ -297,7 +297,7 @@ class Encoder(object):
         return [self.sub.orl(*v) for v in zip(*args)]
 
     def notl(self,arg):
-        return map(self.sub.notl,arg)
+        return list(map(self.sub.notl,arg))
     
     def implies(self,x,y):
         return [self.sub.implies(a,b) for a,b in zip(x,y)]
@@ -321,7 +321,7 @@ class Encoder(object):
                     n = get_encoding_bits(sym.sort)
                     res = self.binenc(int(sym.name),n)
                 elif sym.name in self.ops and il.is_interpreted_sort(sym.sort.dom[0]):
-                    args = map(recur,expr.args)
+                    args = list(map(recur,expr.args))
                     res = self.ops[sym.name](expr.args[0].sort,*args)
                 else:
                     assert len(expr.args) == 0
@@ -331,7 +331,7 @@ class Encoder(object):
                         assert getdef is not None, "no definition for {} in aiger output".format(sym)
                         res = getdef(sym)
             else:
-                args = map(recur,expr.args)
+                args = list(map(recur,expr.args))
                 if isinstance(expr,il.And):
                     res = self.andl(*args)
                 elif isinstance(expr,il.Or):
@@ -541,7 +541,7 @@ class Match(object):
     
 
 def str_map(map):
-    return '{' + ','.join('{}:{}'.format(x,y) for x,y in map.iteritems()) + '}'
+    return '{' + ','.join('{}:{}'.format(x,y) for x,y in map.items()) + '}'
 
 def match_schema_prems(prems,sort_constants,funs,match):
     if len(prems) == 0:
@@ -564,7 +564,7 @@ def match_schema_prems(prems,sort_constants,funs,match):
                 if sym.sort in match.map:
                     cands = sort_constants[match.map[sym.sort]]
                 else:
-                    cands = [s for v in sort_constants.values() for s in v]
+                    cands = [s for v in list(sort_constants.values()) for s in v]
                 for cand in cands:
                     match.push()
                     if match.unify(sym.sort,cand.sort):
@@ -599,10 +599,10 @@ def apply_match(match,fmla):
 def expand_schemata(mod,sort_constants,funs):
     match = Match()
     res = []
-    for s in mod.sig.sorts.values():
+    for s in list(mod.sig.sorts.values()):
         if not il.is_function_sort(s):
             match.add(s,s)
-    for name,lf in mod.schemata.iteritems():
+    for name,lf in mod.schemata.items():
         schema = lf.formula
         if any(name.startswith(pref) for pref in ['rec[','lep[','ind[']):
             continue
@@ -620,12 +620,12 @@ def instantiate_axioms(mod,stvars,trans,invariant,sort_constants,funs):
 
     # Expand the axioms schemata into axioms
 
-    print 'Expanding schemata...'
+    print('Expanding schemata...')
     axioms = mod.labeled_axioms + expand_schemata(mod,sort_constants,funs)
     for a in axioms:
         logfile.write('axiom {}\n'.format(a))
 
-    print 'Instantiating axioms...'
+    print('Instantiating axioms...')
 
     # Get all the triggers. For now only automatic triggers
 
@@ -810,7 +810,7 @@ def clone_normal(expr,args):
 def normalize(expr):
     if il.is_macro(expr):
         return normalize(il.expand_macro(expr))
-    return clone_normal(expr,map(normalize,expr.args))
+    return clone_normal(expr,list(map(normalize,expr.args)))
     
 
 # Class for eliminating quantifiers by finite instantiate. Here,
@@ -845,7 +845,7 @@ class Qelim(object):
             res = self.fresh(expr)
             consts = [self.get_consts(x.sort,sort_constants) for x in expr.variables]
             values = itertools.product(*consts)
-            maps = [dict(zip(expr.variables,v)) for v in values]
+            maps = [dict(list(zip(expr.variables,v))) for v in values]
             insts = [normalize(il.substitute(expr.body,m)) for m in maps]
 #            for i in insts:
 #                print '    {}'.format(i)
@@ -891,18 +891,18 @@ class MatchHandler(object):
             return False
         if il.is_true(cond):
             return True
-        print 'assuming: {}'.format(cond)
+        print('assuming: {}'.format(cond))
         return True
     def handle(self,action,env):
-        print '{}{}'.format(action.lineno,action)
-        print 'env: {}'.format('{'+','.join('{}:{}'.format(x,y) for x,y in env.iteritems())+'}')
+        print('{}{}'.format(action.lineno,action))
+        print('env: {}'.format('{'+','.join('{}:{}'.format(x,y) for x,y in env.items())+'}'))
         
     
 def match_annotation(action,annot,handler):
     def recur(action,annot,env,pos=None):
         if isinstance(annot,ia.RenameAnnotation):
             save = dict()
-            for x,y in annot.map.iteritems():
+            for x,y in annot.map.items():
                 if x in env:
                     save[x] = env[x]
                 env[x] = env.get(y,y)
@@ -929,7 +929,7 @@ def match_annotation(action,annot,handler):
             try:
                 cond = handler.eval(rncond)
             except KeyError:
-                print '{}skipping conditional'.format(action.lineno)
+                print('{}skipping conditional'.format(action.lineno))
 #                exit(1)
 #                iu.dbg('str_map(env)')
 #                iu.dbg('env.get(annot.cond,annot.cond)')
@@ -945,7 +945,7 @@ def match_annotation(action,annot,handler):
             
             annots = unite_annot(annot)
             assert len(annots) == len(action.args)
-            for act,(cond,ann) in reversed(zip(action.args,annots)):
+            for act,(cond,ann) in reversed(list(zip(action.args,annots))):
                 if handler.eval(cond):
                     recur(act,ann,env)
                     return
@@ -975,7 +975,7 @@ def checked(thing):
 def add_err_flag(action,erf,errconds):
     if isinstance(action,ia.AssertAction):
         if checked(action):
-            print "{}Model checking guarantee".format(action.lineno)
+            print("{}Model checking guarantee".format(action.lineno))
             errcond = ilu.dual_formula(il.drop_universals(action.args[0]))
             res = ia.AssignAction(erf,il.Or(erf,errcond))
             errconds.append(errcond)
@@ -986,7 +986,7 @@ def add_err_flag(action,erf,errconds):
             return ia.Sequence()
     if isinstance(action,ia.AssumeAction) or isinstance(action,ia.AssertAction):
         if isinstance(action,ia.AssertAction):
-            print "assuming assertion at line {}".format(action.lineno)
+            print("assuming assertion at line {}".format(action.lineno))
         res = ia.AssumeAction(il.Or(erf,action.args[0])) 
         res.lineno = action.lineno
         return res
@@ -1049,7 +1049,7 @@ def to_table_lookup(trans,invariant):
             for v in values[1:]:
                 res = il.Ite(il.And(*[il.Equals(x,y) for x,y in zip(argsyms,v)]),(expr.rep)(*v),res)
             return res
-        return expr.clone(map(recur,expr.args))
+        return expr.clone(list(map(recur,expr.args)))
 
 
     # skip this step if there aren't any finite-domain functions
@@ -1092,7 +1092,7 @@ def to_aiger(mod,ext_act):
         if not checked(lf):
 #            print 'skipping {}'.format(lf)
             continue
-        print "{}Model checking invariant".format(lf.lineno)
+        print("{}Model checking invariant".format(lf.lineno))
         if lf.id in pmap:
             proof = pmap[lf.id]
             subgoals = pc.admit_proposition(lf,proof)
@@ -1173,7 +1173,7 @@ def to_aiger(mod,ext_act):
     invar_syms.update(ilu.used_symbols_ast(from_asserts))
     sort_constants = mine_constants(mod,trans,il.And(invariant,from_asserts))
     sort_constants2 = mine_constants2(mod,trans,invariant)
-    print '\nInstantiating quantifiers (see {} for instantiations)...'.format(logfile_name)
+    print('\nInstantiating quantifiers (see {} for instantiations)...'.format(logfile_name))
     logfile.write('\ninstantiations:\n')
     trans,invariant = Qelim(sort_constants,sort_constants2)(trans,invariant,indhyps)
     
@@ -1242,10 +1242,10 @@ def to_aiger(mod,ext_act):
             and expr not in il.sig.constructors and expr not in finite_syms_set and not tr.is_skolem(expr)):
             finite_syms_set.add(expr)
             finite_syms.append(expr)
-        return expr.clone(map(mk_prop_abs,expr.args))
+        return expr.clone(list(map(mk_prop_abs,expr.args)))
     
     # apply propositional abstraction to the transition relation
-    new_defs = map(mk_prop_abs,trans.defs)
+    new_defs = list(map(mk_prop_abs,trans.defs))
     new_fmlas = [mk_prop_abs(il.close_formula(fmla)) for fmla in trans.fmlas]
 
     # find any immutable abstract variables, and give them a next definition
@@ -1256,7 +1256,7 @@ def to_aiger(mod,ext_act):
     def is_immutable_expr(expr):
         res = not any(my_is_skolem(sym) or tr.is_new(sym) or sym in stvarset for sym in ilu.used_symbols_ast(expr))
         return res
-    for expr,v in itertools.chain(prop_abs.iteritems(),((x,x) for x in finite_syms)):
+    for expr,v in itertools.chain(iter(prop_abs.items()),((x,x) for x in finite_syms)):
         if is_immutable_expr(expr):
             new_stvars.append(v)
             logfile.write('new state: {}\n'.format(expr))
@@ -1341,12 +1341,12 @@ def to_aiger(mod,ext_act):
 
     # make a decoder for the abstract propositions
 
-    decoder = dict((y,x) for x,y in prop_abs.iteritems())
+    decoder = dict((y,x) for x,y in prop_abs.items())
     for sym in aiger.inputs + aiger.latches:
         if sym not in decoder and sym in orig_syms:
             decoder[sym] = sym
 
-    cnsts = set(sym for syms in sort_constants.values() for sym in syms)
+    cnsts = set(sym for syms in list(sort_constants.values()) for sym in syms)
     return aiger,decoder,annot,cnsts,action,stvarset
 
 def badwit():
@@ -1397,12 +1397,12 @@ class AigerMatchHandler(object):
                     if il.is_constant(expr) and expr in il.sig.constructors:
                         return
                     if not (expr in self.current and self.current[expr] == val):
-                        print '        {} = {}'.format(expr,val)
+                        print('        {} = {}'.format(expr,val))
                         self.current[expr] = val
 
         if hasattr(action,'lineno'):
 #            print '        env: {}'.format('{'+','.join('{}:{}'.format(x,y) for x,y in env.iteritems())+'}')
-            inv_env = dict((y,x) for x,y in env.iteritems() if not my_is_skolem(x))
+            inv_env = dict((y,x) for x,y in env.items() if not my_is_skolem(x))
             for v in self.aiger.inputs:
                 iu.dbg('v')
                 if v in self.decoder:
@@ -1413,7 +1413,7 @@ class AigerMatchHandler(object):
                     decd = self.decoder[v]
                     show_sym(v,ilu.rename_ast(decd,rn),self.aiger.get_next_sym(v))
 
-            print '    {}{}'.format(action.lineno,action)
+            print('    {}{}'.format(action.lineno,action))
         
 class AigerMatchHandler2(ivy_trace.TraceBase):
     def __init__(self,aiger,decoder,cnsts,stvarset,current):
@@ -1453,7 +1453,7 @@ class AigerMatchHandler2(ivy_trace.TraceBase):
                         return
                     eqns.append(il.Equals(expr,val))
 
-        inv_env = dict((y,x) for x,y in env.iteritems() if not my_is_skolem(x))
+        inv_env = dict((y,x) for x,y in env.items() if not my_is_skolem(x))
         eqns = []
         for v in self.aiger.inputs:
             if v in self.decoder:
@@ -1467,7 +1467,7 @@ class AigerMatchHandler2(ivy_trace.TraceBase):
         self.add_state(eqns)
         
     def final_state(self):
-        self.aiger.sub.next()
+        next(self.aiger.sub)
 
         post = self.aiger.sub.latch_vals()  # use this, since file can be wrong!
         stvals = []
@@ -1493,13 +1493,13 @@ def aiger_witness_to_ivy_trace(aiger,witnessfilename,action,stvarset,ext_act,ann
             if line.endswith('\n'):
                 line = line[:-1]
             lines.append(line)
-        print '\nCounterexample follows:'
-        print 80*'-'
+        print('\nCounterexample follows:')
+        print(80*'-')
         current = dict()
         count = 0
         for line in lines:
             if tr:
-                print ''
+                print('')
             cols = line.split(' ')
 #            iu.dbg('cols')
             if len(cols) != 4:
@@ -1515,9 +1515,9 @@ def aiger_witness_to_ivy_trace(aiger,witnessfilename,action,stvarset,ext_act,ann
             # for v in aiger.inputs:
             #     if v in decoder:
             #         print '    {} = {}'.format(decoder[v],aiger.get_sym(v))
-            print 'path:'
+            print('path:')
             match_annotation(action,annot,AigerMatchHandler(aiger,decoder,consts,stvarset,current))
-            aiger.sub.next()
+            next(aiger.sub)
             post = aiger.sub.latch_vals()  # use this, since file can be wrong!
             stvals = []
             stmap = aiger.get_state(post)                     
@@ -1529,14 +1529,14 @@ def aiger_witness_to_ivy_trace(aiger,witnessfilename,action,stvarset,ext_act,ann
                     if val is not None:
                         stvals.append(il.Equals(decoder[v],val))
                         current[decoder[v]] = val
-            print 'state:'
+            print('state:')
             for stval in stvals:
-                print '    {}'.format(stval)
+                print('    {}'.format(stval))
             if not tr:
                 tr = IvyMCTrace(stvals) # first transition is initialization
             else:
                 tr.add_state(stvals,ext_act) # remainder are exported actions
-        print 80*'-'
+        print(80*'-')
         if tr is None:
             badwit()
         return tr
@@ -1552,8 +1552,8 @@ def aiger_witness_to_ivy_trace2(aiger,witnessfilename,action,stvarset,ext_act,an
             if line.endswith('\n'):
                 line = line[:-1]
             lines.append(line)
-        print '\nCounterexample follows:'
-        print 80*'-'
+        print('\nCounterexample follows:')
+        print(80*'-')
         current = dict()
         count = 0
         handler = AigerMatchHandler2(aiger,decoder,consts,stvarset,current)
@@ -1575,8 +1575,8 @@ def aiger_witness_to_ivy_trace2(aiger,witnessfilename,action,stvarset,ext_act,an
             #         print '    {} = {}'.format(decoder[v],aiger.get_sym(v))
             ia.match_annotation(action,annot,handler)
             handler.end()
-        print str(handler)
-        print 80*'-'
+        print(str(handler))
+        print(80*'-')
         if tr is None:
             badwit()
         return tr
@@ -1593,9 +1593,9 @@ class ABCModelChecker(ModelChecker):
 
 def check_isolate():
     
-    print
-    print 80*'*'
-    print
+    print()
+    print(80*'*')
+    print()
 
     global logfile,logfile_name
     if logfile is None:
@@ -1644,8 +1644,8 @@ def check_isolate():
 
     # pass through the stdout and collect it in texts
 
-    print '\nModel checker output:'
-    print 80*'-'
+    print('\nModel checker output:')
+    print(80*'-')
     texts = []
     while True:
         text = p.stdout.read(256)
@@ -1654,7 +1654,7 @@ def check_isolate():
         if len(text) < 256:
             break
     alltext = ''.join(texts)
-    print 80*'-'
+    print(80*'-')
     
     # get the model checker status
 
@@ -1665,15 +1665,15 @@ def check_isolate():
     # scrape the output to get the answer
 
     if mc.scrape(alltext):
-        print '\nPASS'
+        print('\nPASS')
     else:
-        print '\nFAIL'
-        print
-        print 'Counterexample trace follows...'
-        print 80*'*'
+        print('\nFAIL')
+        print()
+        print('Counterexample trace follows...')
+        print(80*'*')
         tr = aiger_witness_to_ivy_trace2(aiger,outfilename,action,stvarset,ext_act,annot,cnsts,decoder)        
-        print
-        print 80*'*'
+        print()
+        print(80*'*')
         exit(0)
         
     

--- a/ivy/ivy_mc.py
+++ b/ivy/ivy_mc.py
@@ -79,7 +79,7 @@ class Aiger(object):
         return res
 
     def notl(self,arg):
-        return 2*(arg/2) + (1 - arg%2)
+        return 2*(arg//2) + (1 - arg%2)
     
     def orl(self,*args):
         return self.notl(self.andl(*list(map(self.notl,args))))

--- a/ivy/ivy_module.py
+++ b/ivy/ivy_module.py
@@ -1,12 +1,12 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-import ivy_utils as iu
-import ivy_logic as il
-import ivy_logic_utils as lu
-import ivy_solver
-import ivy_concept_space as ics
-import ivy_ast
+from . import ivy_utils as iu
+from . import ivy_logic as il
+from . import ivy_logic_utils as lu
+from . import ivy_solver
+from . import ivy_concept_space as ics
+from . import ivy_ast
 
 from collections import defaultdict
 import string
@@ -106,7 +106,7 @@ class Module(object):
 
     def get_axioms(self):
         res = self.axioms
-        for n,sch in self.schemata.iteritems():
+        for n,sch in self.schemata.items():
             res += sch.formula.instances
         return res
 
@@ -209,7 +209,7 @@ class Module(object):
     def copy(self):
         m = Module()
         from copy import copy
-        for x,y in self.__dict__.iteritems():
+        for x,y in self.__dict__.items():
             if x is 'sig':
                 m.__dict__[x] = y.copy()
             else:
@@ -259,7 +259,7 @@ class Module(object):
 
     def call_graph(self):
         callgraph = defaultdict(list)
-        for actname,action in self.actions.iteritems():
+        for actname,action in self.actions.items():
             for called_name in action.iter_calls():
                 callgraph[called_name].append(actname)
         return callgraph
@@ -280,7 +280,7 @@ resort_concept_spaces = resort_asts
 
 def resort_map_symbol_sort(m):
     return dict((lu.resort_symbol(sym,sort_refinement),lu.resort_sort(sort,sort_refinement))
-                for sym,sort in m.iteritems())
+                for sym,sort in m.items())
 
 def resort_name_ast_pairs(pairs):
     return [(n,lu.resort_ast(a,sort_refinement)) for n,a in pairs]
@@ -297,12 +297,12 @@ def remove_refined_sortnames_from_list(sorts):
     return list(n for n in sorts if n not in refd)
 
 def resort_aliases_map(amap):
-    res = dict(amap.iteritems())
-    for s1,s2 in sort_refinement.iteritems():
+    res = dict(iter(amap.items()))
+    for s1,s2 in sort_refinement.items():
         res[s1.name] = s2.name
 
 def resort_map_any_ast(m):
-    return dict((a,lu.resort_ast(b,sort_refinement)) for a,b in m.iteritems())
+    return dict((a,lu.resort_ast(b,sort_refinement)) for a,b in m.items())
 
 
 module = None
@@ -316,7 +316,7 @@ def instantiate_non_epr(non_epr,ground_terms):
                 ldf,cnst = non_epr[term.rep]
                 subst = dict((v,t) for v,t in zip(ldf.formula.args[0].args,term.args)
                              if not isinstance(v,il.Variable))
-                if all(lu.is_ground_ast(x) for x in subst.values()):
+                if all(lu.is_ground_ast(x) for x in list(subst.values())):
                        inst = lu.substitute_constants_ast(cnst,subst)
                        theory.append(inst)
 #                iu.dbg('inst')

--- a/ivy/ivy_module.py
+++ b/ivy/ivy_module.py
@@ -117,7 +117,7 @@ class Module(object):
 
     def add_to_hierarchy(self,name):
         if iu.ivy_compose_character in name:
-            pref,suff = string.rsplit(name,iu.ivy_compose_character,1)
+            pref,suff = name.rsplit(iu.ivy_compose_character,1)
             self.add_to_hierarchy(pref)
             self.hierarchy[pref].add(suff)
         else:

--- a/ivy/ivy_module.py
+++ b/ivy/ivy_module.py
@@ -210,7 +210,7 @@ class Module(object):
         m = Module()
         from copy import copy
         for x,y in self.__dict__.items():
-            if x is 'sig':
+            if x == 'sig':
                 m.__dict__[x] = y.copy()
             else:
                 m.__dict__[x] = copy(y)

--- a/ivy/ivy_parser.py
+++ b/ivy/ivy_parser.py
@@ -1,11 +1,11 @@
 
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_concept_space import NamedSpace, ProductSpace, SumSpace
-from ivy_ast import *
-from ivy_actions import AssumeAction, AssertAction, EnsuresAction, SetAction, AssignAction, VarAction, HavocAction, IfAction, AssignFieldAction, NullFieldAction, CopyFieldAction, InstantiateAction, CallAction, LocalAction, LetAction, Sequence, UpdatePattern, PatternBasedUpdate, SymbolList, UpdatePatternList, Schema, ChoiceAction, NativeAction, WhileAction, Ranking, RequiresAction, EnsuresAction, CrashAction, ThunkAction
-from ivy_lexer import *
-import ivy_utils as iu
+from .ivy_concept_space import NamedSpace, ProductSpace, SumSpace
+from .ivy_ast import *
+from .ivy_actions import AssumeAction, AssertAction, EnsuresAction, SetAction, AssignAction, VarAction, HavocAction, IfAction, AssignFieldAction, NullFieldAction, CopyFieldAction, InstantiateAction, CallAction, LocalAction, LetAction, Sequence, UpdatePattern, PatternBasedUpdate, SymbolList, UpdatePatternList, Schema, ChoiceAction, NativeAction, WhileAction, Ranking, RequiresAction, EnsuresAction, CrashAction, ThunkAction
+from .ivy_lexer import *
+from . import ivy_utils as iu
 import copy
 from collections import defaultdict
 
@@ -131,7 +131,7 @@ def inst_mod(ivy,module,pref,subst,vsubst):
             if vsubst:
                 map1 = distinct_variable_renaming(used_variables_ast(pref),used_variables_ast(decl))
                 vpref = substitute_ast(pref,map1)
-                vvsubst = dict((x,map1[y.rep]) for x,y in vsubst.iteritems())
+                vvsubst = dict((x,map1[y.rep]) for x,y in vsubst.items())
                 idecl = AttributeDecl(*[x.clone([compose_atoms(vpref,x.args[0]),x.args[1]]) for x in decl.args]) if vpref is not None else decl
                 idecl = substitute_constants_ast(idecl,vvsubst)
             else:
@@ -139,7 +139,7 @@ def inst_mod(ivy,module,pref,subst,vsubst):
         elif vsubst:
             map1 = distinct_variable_renaming(used_variables_ast(pref),used_variables_ast(decl))
             vpref = substitute_ast(pref,map1)
-            vvsubst = dict((x,map1[y.rep]) for x,y in vsubst.iteritems())
+            vvsubst = dict((x,map1[y.rep]) for x,y in vsubst.items())
             idecl = subst_prefix_atoms_ast(decl,subst,vpref,module.defined,static=module.static)
             idecl = substitute_constants_ast2(idecl,vvsubst)
         else:
@@ -147,7 +147,7 @@ def inst_mod(ivy,module,pref,subst,vsubst):
         if isinstance(idecl,ActionDecl):
             for foo in idecl.args:
                 if not hasattr(foo.args[1],'lineno'):
-                    print 'no lineno: {}'.format(foo)
+                    print('no lineno: {}'.format(foo))
         idecl.attributes = decl.attributes
         ivy.declare(idecl)
     ivy.attributes = save
@@ -169,7 +169,7 @@ def do_insts(ivy,insts):
             subst = dict((x.rep,y.rep) for x,y in zip(fparams,aparams) if not isinstance(y,Variable))
             vsubst = dict((x.rep,y) for x,y in zip(fparams,aparams) if isinstance(y,Variable))
             pvars = set(x.rep for x in pref.args) if pref != None else set()
-            for v in vsubst.values():
+            for v in list(vsubst.values()):
                 if v.rep not in pvars:
                     raise iu.IvyError(instantiation,"variable {} is unbound".format(v))
             module = defn.args[1]
@@ -1561,7 +1561,7 @@ else:
     p[0].declare(decl)
     for foo in decl.args:
         if not hasattr(foo.args[1],'lineno'):
-            print 'no lineno!!!: {}'.format(foo)
+            print('no lineno!!!: {}'.format(foo))
     if p[2]:
         if p[2] == ExportDecl:
             d = ExportDecl(ExportDef(Atom(p[4]),Atom('')))
@@ -2651,7 +2651,7 @@ def p_state_expr_entry(p):
     'state_expr : ENTRY'
     p[0] = RME(And(),[],And())
 
-from ivy_logic_parser import *
+from .ivy_logic_parser import *
 
 def p_error(token):
     if token is not None:
@@ -2693,7 +2693,7 @@ def expand_autoinstances(ivy):
                     for inst in autos[key]:
                         pref,parms = iu.extract_parameters_name(inst.args[0].rep)
                         lhs = Atom(tname,[]) 
-                        subst = dict(zip(parms,refparms))
+                        subst = dict(list(zip(parms,refparms)))
                         rhs = inst.args[1].clone([Atom(subst.get(a.rep,a.rep),[]) for a in inst.args[1].args])
                         newinst = Instantiation(lhs,rhs)
                         do_insts(ivy,[newinst])
@@ -2728,10 +2728,10 @@ if __name__ == '__main__':
        s = open('test.ivy','rU').read()
        try:
            result = parse(s)
-           print result
-           print result.defined
+           print(result)
+           print(result.defined)
        except iu.ErrorList as e:
-           print repr(e)
+           print(repr(e))
 #       print "enum: %s" % result.enumerate(dict(),lambda x:True)
 
 def clauses_to_concept(name,clauses):

--- a/ivy/ivy_parser.py
+++ b/ivy/ivy_parser.py
@@ -1862,8 +1862,8 @@ def p_top_interpret_symbol_arrow_lcb_symbol_moresymbols_rcb(p):
     p[0].declare(thing)
 
 def parse_nativequote(p,n):
-    string = p[n][3:-3] # drop the quotation marks
-    fields = string.split('`')
+    s = p[n][3:-3] # drop the quotation marks
+    fields = s.split('`')
     bqs = [(Atom(This()) if s == 'this' else Atom(s))  for idx,s in enumerate(fields) if idx % 2 == 1]
     text = "`".join([(s if idx % 2 == 0 else str(idx/2)) for idx,s in enumerate(fields)])
     eols = [sum(1 for c in s if c == '\n') for idx,s in enumerate(fields) if idx % 2 == 0]

--- a/ivy/ivy_parser.py
+++ b/ivy/ivy_parser.py
@@ -1865,7 +1865,7 @@ def parse_nativequote(p,n):
     s = p[n][3:-3] # drop the quotation marks
     fields = s.split('`')
     bqs = [(Atom(This()) if s == 'this' else Atom(s))  for idx,s in enumerate(fields) if idx % 2 == 1]
-    text = "`".join([(s if idx % 2 == 0 else str(idx/2)) for idx,s in enumerate(fields)])
+    text = "`".join([(s if idx % 2 == 0 else str(idx//2)) for idx,s in enumerate(fields)])
     eols = [sum(1 for c in s if c == '\n') for idx,s in enumerate(fields) if idx % 2 == 0]
     seols = 0
     loc = get_lineno(p,n)

--- a/ivy/ivy_printer.py
+++ b/ivy/ivy_printer.py
@@ -1,6 +1,6 @@
-import ivy_logic
-import ivy_utils as iu
-import ivy_actions as ia
+from . import ivy_logic
+from . import ivy_utils as iu
+from . import ivy_actions as ia
 
 def labeled_fmlas_to_str(kwd,lfmlas):
     res = ''
@@ -12,7 +12,7 @@ def labeled_fmlas_to_str(kwd,lfmlas):
     return res
 
 def print_module(mod):
-    print ivy_logic.sig
+    print(ivy_logic.sig)
     thing = ''
     for kwd,lst in [('axiom',mod.labeled_axioms),
                     ('property',mod.labeled_props),
@@ -25,14 +25,14 @@ def print_module(mod):
 
     for tn in sorted(mod.sig.interp):
         thing += "interp {} -> {}\n".format(tn,mod.sig.interp[tn])
-    print thing
+    print(thing)
 
     for name,action in mod.initializers:
-        print iu.pretty("after init {" + str(action) + "}")
+        print(iu.pretty("after init {" + str(action) + "}"))
 
-    for x,y in mod.actions.iteritems():
-        print iu.pretty(ia.action_def_to_str(x,y))
+    for x,y in mod.actions.items():
+        print(iu.pretty(ia.action_def_to_str(x,y)))
 
     for x in sorted(mod.public_actions):
-        print 'export {}'.format(x)
+        print('export {}'.format(x))
 

--- a/ivy/ivy_proof.py
+++ b/ivy/ivy_proof.py
@@ -2,11 +2,11 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_utils as iu
-import ivy_logic as il
-import ivy_logic_utils as lu
-import ivy_ast as ia
-import logic_util
+from . import ivy_utils as iu
+from . import ivy_logic as il
+from . import ivy_logic_utils as lu
+from . import ivy_ast as ia
+from . import logic_util
 
 class Redefinition(iu.IvyError):
     pass
@@ -27,7 +27,7 @@ class MatchProblem(object):
         self.prem_matches=prem_matches
         self.revmap = dict()
     def __str__(self):
-        return '{{pat:{},inst:{},freesyms:{}}}'.format(self.pat,self.inst,map(str,self.freesyms))
+        return '{{pat:{},inst:{},freesyms:{}}}'.format(self.pat,self.inst,list(map(str,self.freesyms)))
 
 def attrib_goals(proof,goals):
     if hasattr(proof,'lineno'):
@@ -51,14 +51,14 @@ class ProofChecker(object):
     
         self.axioms  = [normalize_goal(ax) for ax in axioms]
         self.definitions = dict((d.formula.defines().name,normalize_goal(d)) for d in definitions)
-        self.schemata = dict((x,normalize_goal(y)) for x,y in schemata.iteritems()) if schemata is not None else dict()
+        self.schemata = dict((x,normalize_goal(y)) for x,y in schemata.items()) if schemata is not None else dict()
         for ax in axioms:
             if ax.label is not None:
                 self.schemata[ax.name] = ax
         self.stale = set() # set of symbols that are not fresh
         for lf in axioms + definitions:
             self.stale.update(lu.used_symbols_ast(lf.formula))
-        for goal in schemata.values():
+        for goal in list(schemata.values()):
             vocab = goal_vocab(goal)
             self.stale.update(vocab.symbols)
 
@@ -194,12 +194,12 @@ class ProofChecker(object):
         return decls
 
     def show_goals_tactic(self,decls,proof):
-        print
-        print '{}Proof goals:'.format(proof.lineno)
+        print()
+        print('{}Proof goals:'.format(proof.lineno))
         for decl in decls:
-            print
-            print 'theorem ' + str(decl)
-            print
+            print()
+            print('theorem ' + str(decl))
+            print()
         return decls
 
     def defer_goal_tactic(self,decls,proof):
@@ -209,7 +209,7 @@ class ProofChecker(object):
         cond = il.And(*[il.Equals(x,y) for x,y in proof.args])
         subgoal = ia.LabeledFormula(decls[0].label,il.Implies(cond,decls[0].formula))
         if not hasattr(decls[0],'lineno'):
-            print 'has no line number: {}'.format(decls[0])
+            print('has no line number: {}'.format(decls[0]))
             exit(1)
         subgoal.lineno = decls[0].lineno
         return attrib_goals(proof,[subgoal]) + decls[1:]
@@ -344,8 +344,8 @@ class ProofChecker(object):
         prob, pmatch = self.setup_schema_matching(decl,proof,schema,allow_witness=True)
         def iswit(x):
             return isinstance(x,il.Variable) and x not in prob.freesyms
-        witness = dict((x,y) for x,y in pmatch.iteritems() if iswit(x))
-        pmatch = dict((x,y) for x,y in pmatch.iteritems() if not iswit(x))
+        witness = dict((x,y) for x,y in pmatch.items() if iswit(x))
+        pmatch = dict((x,y) for x,y in pmatch.items() if not iswit(x))
 #        prem = make_goal(proof.lineno,fresh_label(goal_prems(decl)),[],schema)
         prem = prob.schema
         if schemaname not in premmap:
@@ -527,7 +527,7 @@ def goal_prem_goals(goal):
 # Check that there are no name clashes in a pair of goals
 
 def check_name_clash(g1,g2):
-    d1,d2 = map(goal_defns,(g1,g2))
+    d1,d2 = list(map(goal_defns,(g1,g2)))
     for s1 in d1:
         if s1 in d2:
             raise ProofError(None,'premise {} of sugboal clashes with context'.format(s1))
@@ -553,7 +553,7 @@ def goal_vocab(goal):
 # Check that the conclusions of two goals match
 
 def check_concs_match(g1,g2):
-    c1,c2 = map(goal_conc,(g1,g2))
+    c1,c2 = list(map(goal_conc,(g1,g2)))
     if not il.equal_mod_alpha(c1,c2):
         raise ProofError(None,'conclusions do not match:\n    {}\n     {}'.format(c1,c2))
 
@@ -584,9 +584,9 @@ def normalize_goal(x):
     if goal_is_defn(x):
         return x
     if not hasattr(x,'formula'):
-        print x
-        print type(x)
-    return clone_goal(x,map(normalize_goal,goal_prems(x)),il.normalize_ops(goal_conc(x)))
+        print(x)
+        print(type(x))
+    return clone_goal(x,list(map(normalize_goal,goal_prems(x))),il.normalize_ops(goal_conc(x)))
 
 def get_unprovided_defns(g1,g2):
     defns = goal_defns(g2)
@@ -652,7 +652,7 @@ def check_schema_capture(schema,goal):
             raise CaptureError(None,'"{}" is captured when importing "{}"'.format(sym,schema.name))
 
 def check_alpha_capture(goal,match):
-    rev_match = dict((y,x) for x,y in match.iteritems())
+    rev_match = dict((y,x) for x,y in match.items())
     for s in goal_free(goal).union(goal_defns(goal)):
         if s in rev_match and s not in match:
             raise CaptureError(None,'"{}" is captured by renaming "{}"'.format(s,rev_match[s]))
@@ -678,9 +678,9 @@ def rename_goal(goal,renaming):
     def rec_goal(goal):
         if not isinstance(goal,ia.LabeledFormula):
             return goal
-        goal = clone_goal(goal,map(rec_goal,goal_prems(goal)),goal_conc(goal))
+        goal = clone_goal(goal,list(map(rec_goal,goal_prems(goal))),goal_conc(goal))
         match = dict((x,x.rename(lambda n: rmap[x.name])) for x in goal_defns(goal) if x.name in rmap)
-        match = dict((x,apply_match_sym(match,y)) for x,y in match.iteritems())
+        match = dict((x,apply_match_sym(match,y)) for x,y in match.items())
         check_alpha_capture(goal,match)
         goal = apply_match_goal(match,goal,apply_match_alt)
         goal = clone_goal(goal,goal_prems(goal),il.alpha_rename(rmap,goal_conc(goal)))
@@ -711,8 +711,8 @@ def remove_vars_match(mat,fmla):
     """ Remove the variables bindings from a match. This is used to
     prevent variable capture when applying the match to premises. Make sure free variables
     are not captured by fmla """
-    res = dict((s,v) for s,v in mat.iteritems() if il.is_ui_sort(s))
-    sympairs = [(s,v) for s,v in mat.iteritems() if il.is_constant(s)]
+    res = dict((s,v) for s,v in mat.items() if il.is_ui_sort(s))
+    sympairs = [(s,v) for s,v in mat.items() if il.is_constant(s)]
     symfmlas = il.rename_vars_no_clash([v for s,v in sympairs],[fmla])
     res.update((s,w) for (s,v),w in zip(sympairs,symfmlas))
     return res
@@ -720,12 +720,12 @@ def remove_vars_match(mat,fmla):
 
 def show_match(m):
     if m is None:
-        print 'no match'
+        print('no match')
         return 
-    print 'match {'
-    for x,y in m.iteritems():
-        print '{} : {} |-> {}'.format(x,x.sort if hasattr(x,'sort') else 'type',y)
-    print '}'
+    print('match {')
+    for x,y in m.items():
+        print('{} : {} |-> {}'.format(x,x.sort if hasattr(x,'sort') else 'type',y))
+    print('}')
         
 def match_problem(schema,decl):
     """ Creating a matching problem from a schema and a declaration """
@@ -771,12 +771,12 @@ def transform_defn_match(prob):
     for x,y in zip(func_sorts(concsym),func_sorts(declsym)):
         if x in freesyms:
             if x in dmatch and dmatch[x] != y:
-                print "lhs sorts didn't match: {}, {}".format(x,y)
+                print("lhs sorts didn't match: {}, {}".format(x,y))
                 return None
             dmatch[x] = y
         else:
             if x != y:
-                print "lhs sorts didn't match: {}, {}".format(x,y)
+                print("lhs sorts didn't match: {}, {}".format(x,y))
                 return None
     concrhs = apply_match(dmatch,concrhs)
     freesyms = apply_match_freesyms(dmatch,freesyms)
@@ -906,7 +906,7 @@ def compile_match(proof_match,prob,decl,allow_witness=False):
 def match_rhs_vars(match):
     """ Get the symbols occurring free on the right-hand side of a match """
     res = set()
-    for w in match.values():
+    for w in list(match.values()):
         for v in w if isinstance(w,list) else [w]:
             if isinstance(v,il.UninterpretedSort):
                 res.add(v)
@@ -940,8 +940,8 @@ def apply_match_goal(match,x,apply_match,env = None):
 def apply_match_match(match,orig_match,apply_match):
     """ Apply a match match to match orig_match. Applying the resulting match should
     have the same effect as apply first orig_match, then match. """
-    orig_match = dict((x,apply_match(match,y)) for x,y in orig_match.iteritems())
-    orig_match.update((x,y) for x,y in match.iteritems() if x not in orig_match)
+    orig_match = dict((x,apply_match(match,y)) for x,y in orig_match.items())
+    orig_match.update((x,y) for x,y in match.items() if x not in orig_match)
     return orig_match
 
 def apply_match_to_problem(match,prob,apply_match):
@@ -949,13 +949,13 @@ def apply_match_to_problem(match,prob,apply_match):
     prob.schema = apply_match_goal(match,prob.schema,apply_match)
     prob.pat = apply_match(match,prob.pat)
     prob.freesyms = apply_match_freesyms(match,prob.freesyms)
-    prob.revmap = dict((x,y) for x,y in prob.revmap.iteritems() if x not in match)
+    prob.revmap = dict((x,y) for x,y in prob.revmap.items() if x not in match)
 
 def rename_problem(match,prob):
     prob.schema = apply_match_goal(match,prob.schema,apply_match_alt)
     prob.pat = apply_match_alt(match,prob.pat)
     prob.freesyms = set(match.get(sym,sym) for sym in prob.freesyms)
-    prob.revmap.update((y,x) for x,y in match.iteritems())
+    prob.revmap.update((y,x) for x,y in match.items())
 
 def avoid_capture_problem(prob,match):
     """ Rename a match problem to avoid capture when applying a
@@ -977,7 +977,7 @@ def detect_nonce_symbols(prob):
     remains after matching, we report the original symbol
     as clashing with the corresponding symbol in the goal."""
 
-    for sym in prob.revmap.values():
+    for sym in list(prob.revmap.values()):
         raise CaptureError(None,'Symbol {} in schema clashes with {} in goal.\nSuggest renaming or instantiating it.'.format(sym,sym))
 
 def trivial_goal(goal):
@@ -1149,7 +1149,7 @@ def term_sorts(term):
     return func_sorts(term.rep) if il.is_app(term) else [term.sort] if il.is_variable(term) else []
 
 def funcs_match(pat,inst,freesyms):
-    psorts,isorts = map(func_sorts,(pat,inst))
+    psorts,isorts = list(map(func_sorts,(pat,inst)))
     res = (pat.name == inst.name and len(psorts) == len(isorts)
             and all(x == y for x,y in zip(psorts,isorts) if x not in freesyms))
     return res
@@ -1180,7 +1180,7 @@ def extract_terms(inst,terms):
         for term,var in zip(terms,vars):
             if term == inst:
                 return var
-        return inst.clone(map(rec,inst.args))
+        return inst.clone(list(map(rec,inst.args)))
     return il.Lambda(vars,rec(inst))
 
 def fo_match(pat,inst,freesyms,constants):
@@ -1277,9 +1277,9 @@ def merge_matches(*matches):
         return dict()
     if any(match is None for match in matches):
         return None
-    res = dict(matches[0].iteritems())
+    res = dict(iter(matches[0].items()))
     for match2 in matches[1:]:
-        for sym,lmda in match2.iteritems():
+        for sym,lmda in match2.items():
             if sym in res:
                 if not equiv_alpha(lmda,res[sym]):
                     return None
@@ -1294,7 +1294,7 @@ def equiv_alpha(x,y):
     if x == y:
         return True
     if il.is_lambda(x) and il.is_lambda(y):
-        return x.body == il.substitute(y.body,zip(x.variables,y.variables))
+        return x.body == il.substitute(y.body,list(zip(x.variables,y.variables)))
     return False
     pass
 

--- a/ivy/ivy_resolution.py
+++ b/ivy/ivy_resolution.py
@@ -1,8 +1,8 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_logic import *
-from ivy_logic_utils import *
+from .ivy_logic import *
+from .ivy_logic_utils import *
 
 def env_find(env, t):
     v = t
@@ -35,7 +35,7 @@ def terms_mgu(terms1, terms2):
 
     #print env
 
-    subs = dict( (rep, env_find(env, env[rep])) for rep in env.iterkeys() )
+    subs = dict( (rep, env_find(env, env[rep])) for rep in env.keys() )
     return True, subs
 
 def test_terms_mgu():
@@ -88,7 +88,7 @@ def terms_mgu_eq(terms1, terms2):
 
     #print env
 
-    subs = dict( (rep, env_find(env, env[rep])) for rep in env.iterkeys() )
+    subs = dict( (rep, env_find(env, env[rep])) for rep in env.keys() )
     return True, subs, eqs
 
 

--- a/ivy/ivy_show.py
+++ b/ivy/ivy_show.py
@@ -1,21 +1,21 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-import ivy
-import ivy_interp as itp
-import ivy_actions as act
-import ivy_utils as utl
-import ivy_logic_utils as lut
-import tk_ui as ui
-import ivy_logic as lg
-import ivy_utils as iu
-import ivy_module as im
-import ivy_alpha
-import ivy_art
-import ivy_interp
-import ivy_compiler
-import ivy_isolate
-import ivy_init
+from . import ivy
+from . import ivy_interp as itp
+from . import ivy_actions as act
+from . import ivy_utils as utl
+from . import ivy_logic_utils as lut
+from . import tk_ui as ui
+from . import ivy_logic as lg
+from . import ivy_utils as iu
+from . import ivy_module as im
+from . import ivy_alpha
+from . import ivy_art
+from . import ivy_interp
+from . import ivy_compiler
+from . import ivy_isolate
+from . import ivy_init
 
 import sys
 
@@ -23,7 +23,7 @@ diagnose = iu.BooleanParameter("diagnose",False)
 
     
 def usage():
-    print "usage: \n  {} file.ivy".format(sys.argv[0])
+    print("usage: \n  {} file.ivy".format(sys.argv[0]))
     sys.exit(1)
 
 def check_module():

--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -12,15 +12,15 @@ import re
 import functools
 
 import z3
-import ivy_logic
-from ivy_logic_utils import used_variables_clause, used_variables_ast, variables_ast,\
+from . import ivy_logic
+from .ivy_logic_utils import used_variables_clause, used_variables_ast, variables_ast,\
    to_clauses, constants_clauses, used_relations_clauses, rel_inst, fun_eq_inst, \
    is_ground_lit, used_constants_clauses, substitute_constants_clauses, eq_atom, \
    functions_clauses, fun_inst, substitute_lit, used_constants_clause, used_symbols_clause,Clauses, used_symbols_clause, and_clauses, true_clauses, used_symbols_ast, sym_placeholders, used_symbols_clauses, ground_apps_clauses, dual_clauses
-from ivy_core import minimize_core, biased_core
-import ivy_utils as iu
-import ivy_unitres as ur
-import logic as lg
+from .ivy_core import minimize_core, biased_core
+from . import ivy_utils as iu
+from . import ivy_unitres as ur
+from . import logic as lg
 
 import sys
 
@@ -32,7 +32,7 @@ z3_to_expr_ref = z3._to_expr_ref if '_to_expr_ref' in z3.__dict__ else z3.z3._to
 use_z3_enums = True
 
 def set_seed(seed):
-    print 'setting seed to {}'.format(seed)
+    print('setting seed to {}'.format(seed))
     z3.set_param('smt.random_seed',seed)
 
 opt_seed = iu.Parameter("seed",0,process=int)
@@ -286,7 +286,7 @@ def check_native_compat_sym(sym):
         raise iu.IvyError(None,'cannot interpret {} as {}: {}'.format(sym,ivy_logic.sig.interp[sym.name],e))
 
 def check_compat():
-    for name,value in ivy_logic.sig.interp.iteritems():
+    for name,value in ivy_logic.sig.interp.items():
         if name in ivy_logic.sig.symbols:
             sym = ivy_logic.sig.symbols[name]
             sorts = sym.sort.sorts if isinstance(sym.sort,ivy_logic.UnionSort) else [sym.sort]
@@ -379,8 +379,8 @@ def term_to_z3(term):
         return z3.If(formula_to_z3_int(term.args[0]),term_to_z3(term.args[1]),term_to_z3(term.args[2]))
     else:
         if not hasattr(term,'rep'):
-            print term
-            print term.lineno
+            print(term)
+            print(term.lineno)
         fun = z3_functions.get(term.rep)
         if fun is None:
             fun = lookup_native(term.rep,functions,"function")
@@ -526,7 +526,7 @@ def formula_to_z3_int(fmla):
         return res
     if ivy_logic.is_individual(fmla):
         return term_to_z3(fmla)
-    print "bad fmla: {!r}".format(fmla)
+    print("bad fmla: {!r}".format(fmla))
     assert False
 
 def formula_to_z3_closed(fmla):
@@ -656,7 +656,7 @@ class SortOrder(object):
         self.order = order
         self.model = model
     def __call__(self,x,y):
-        interp = zip(self.vs,(x,y))
+        interp = list(zip(self.vs,(x,y)))
         fact = substitute(self.order,*interp)
         fact_val = self.model.eval(fact)
 #        print "order: %s = %s" % (fact,fact_val)
@@ -674,7 +674,7 @@ def collect_numerals(z3term):
 def from_z3_numeral(z3term,sort):
     name = str(z3term)
     if not(name[0].isdigit() or name[0] == '"' or name[0] == '-'):
-        print "unexpected numeral from Z3 model: {}".format(name)
+        print("unexpected numeral from Z3 model: {}".format(name))
     return ivy_logic.Symbol(name,sort)
 
 def collect_model_values(sort,model,sym):
@@ -690,7 +690,7 @@ def mine_interpreted_constants(model,vocab):
         sort = s.sort.rng
         if sort in sort_values:
             sort_values[sort].update(collect_model_values(sort,model,s))
-    return dict((x,map(term_to_z3,list(y))) for x,y in sort_values.iteritems())
+    return dict((x,list(map(term_to_z3,list(y)))) for x,y in sort_values.items())
     
 def enumerated_range(sort):
     res = [z3_constants[x] for x in sort.defines()]
@@ -717,7 +717,7 @@ class HerbrandModel(object):
         vs = [ivy_logic.Variable(s,sort) for s in ["X","Y"]]
         order = ivy_logic.Symbol("<",ivy_logic.RelationSort([sort,sort]))
         order_atom = atom_to_z3(order(*vs))
-        z3_vs = map(term_to_z3,vs)
+        z3_vs = list(map(term_to_z3,vs))
 #        print "order_atom: {}".format(order_atom)
         try:
             fun = z3.Function
@@ -752,7 +752,7 @@ class HerbrandModel(object):
         z3_vs = [term_to_z3(v) for v in vs]
         insts = []
         for tup in itertools.product(*ranges):
-            interp = zip(z3_vs,tup)
+            interp = list(zip(z3_vs,tup))
             fact = substitute(z3_fmla,*interp)
             fact_val = m.eval(fact,model_completion=True)
 #            print "%s = %s" % (fact,fact_val)
@@ -796,7 +796,7 @@ def get_model_constant(m,t):
 #        print "model: {}".format(m.sexpr())
 #        print "term: {}".format(t)
         res = ivy_logic.Constant(ivy_logic.Symbol(s.defines()[0],s))
-        print "warning: model doesn't give a value for enumerated term {}. returning {}.".format(t,res)
+        print("warning: model doesn't give a value for enumerated term {}. returning {}.".format(t,res))
         return res
 #        assert False # model doesn't give a value for enumerated term
     return constant_from_z3(s,m.eval(term_to_z3(t),model_completion=True))
@@ -825,7 +825,7 @@ def clauses_imply_list(clauses1, clauses2_list):
     s.add(z1)
 
     res = []
-    negs = map(dual_clauses,clauses2_list)
+    negs = list(map(dual_clauses,clauses2_list))
         
     for clauses2 in negs:
         z2 = clauses_to_z3(clauses2)
@@ -1021,7 +1021,7 @@ def model_if_none(clauses1,implied,model):
                 s.add(formula_to_z3(sort_size_constraint(sort,sort_size)))
             if s.check() != z3.unsat:
                 m = get_model(s)
-                print "model = {}, size = {}".format(m,sort_size)
+                print("model = {}, size = {}".format(m,sort_size))
 ##        print "clauses1 = {}".format(clauses1)
 ##        print "z3c = {}".format(str(z3c))
                 syms = used_symbols_clauses(clauses1)
@@ -1042,7 +1042,7 @@ def decide(s,atoms=None):
 #    f.close()
     res = s.check() if atoms == None else s.check(atoms)
     if res == z3.unknown:
-        print s.to_smt2()
+        print(s.to_smt2())
         raise iu.IvyError(None,"Solver produced inconclusive result")
 #    print "}"
     return res
@@ -1073,15 +1073,15 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
     """
 
     if opt_show_vcs.get():
-        print ''
-        print "definitions:"
+        print('')
+        print("definitions:")
         for df in clauses.defs:
-            print df
-            print
-        print "axioms:"
+            print(df)
+            print()
+        print("axioms:")
         for fmla in clauses.fmlas:
-            print fmla
-            print
+            print(fmla)
+            print()
 
     s = z3.Solver()
     the_fmla = clauses_to_z3(clauses)
@@ -1105,7 +1105,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
                 fc.start()
                 if fc.assume():
                     if opt_show_vcs.get():
-                        print '\nassume: {}'.format(fc.cond())
+                        print('\nassume: {}'.format(fc.cond()))
                     s.add(clauses_to_z3(fc.cond()))
                     assumes.append(fc.cond())
                 else:
@@ -1113,7 +1113,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
                         s.push()
                     foo = fc.cond()
                     if opt_show_vcs.get():
-                        print '\nassert: {}'.format(foo)
+                        print('\nassert: {}'.format(foo))
                     the_fmla = clauses_to_z3(foo)
 #                    iu.dbg('the_fmla')
                     s.add(the_fmla)
@@ -1136,7 +1136,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
         return None
 
     if shrink:
-        print "searching for a small model...",
+        print("searching for a small model...", end=' ')
         sys.stdout.flush()
         for x in chain(sorts_to_minimize, relations_to_minimize):
             for n in itertools.count(1):
@@ -1148,7 +1148,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
                     break
                 else:
                     s.pop()
-        print "done"
+        print("done")
     m = get_model(s)
 #    print "model = {}".format(m)
 #    f = open("ivy.smt2","w")
@@ -1189,9 +1189,9 @@ def model_facts(h,ignore,clauses1,upclose=False):
 #    print "model_facts vc = {}".format(vc)
     # values of relations in formula
 #    print "used_relations_clauses = {}".format(used_relations_clauses(clauses1))
-    urc = dict((ivy_logic.normalize_symbol(r),n) for r,n in used_relations_clauses(clauses1).iteritems())
+    urc = dict((ivy_logic.normalize_symbol(r),n) for r,n in used_relations_clauses(clauses1).items())
     vr = [[l]
-          for (r,n) in urc.iteritems()
+          for (r,n) in urc.items()
           if not ignore(r)
           for l in relation_model_to_clauses(h,r,n)]
     # values of functions in formula
@@ -1223,7 +1223,7 @@ def numeral_assign(clauses,h):
             numv = h.eval_constant(num)
 #            print "eval: {}:{} = {}".format(num,num.sort,numv)
             if numv in foom:
-                print "two numerals assigned same value!: {} = {}".format(num,foom[numv])
+                print("two numerals assigned same value!: {} = {}".format(num,foom[numv]))
             else:
 #                print "assigning {} to {}".format(num,numv)
                 foom[numv] = num
@@ -1282,7 +1282,7 @@ def bound_quantifiers_clauses(h,clauses,reps):
        bq_res = ivy_logic.Implies(ivy_logic.And(*cnsts),fmla) if cnsts else fmla
        return bq_res
 
-   new_fmlas = map(bq,clauses.fmlas)
+   new_fmlas = list(map(bq,clauses.fmlas))
    return Clauses(fmlas=new_fmlas,defs=list(clauses.defs))
 
 def filter_redundant_facts(clauses,axioms):
@@ -1372,7 +1372,7 @@ def clauses_model_to_diagram(clauses1,ignore = None, implied = None,model = None
 #    print "foo = {}".format(unsat_core(and_clauses(uc,axioms),true_clauses(),clauses1))
 
     # filter out non-rep skolems
-    repset = set(c.rep for e,c in reps.iteritems())
+    repset = set(c.rep for e,c in reps.items())
 #    print "clauses_model_to_diagram repset = {}".format(repset)
     ign = lambda x,ignore=ignore: (ignore(x) and not x in repset)
     res = Clauses([cl for cl in res.fmlas if not any(ign(c) for c in used_symbols_ast(cl))])
@@ -1394,7 +1394,7 @@ def get_lit_facts(h,lit,res):
 ##    print "rows = {}".format(rows)
     for r in rows:
 ##        print "r = {}".format(r)
-        subst = dict(zip([v.rep for v in vs],r))
+        subst = dict(list(zip([v.rep for v in vs],r)))
 ##        print "subst = {}".format(subst)
         res += [substitute_lit(lit,subst)]
 
@@ -1458,7 +1458,7 @@ def encode_term(t,n,sort):
         try:
             m = sort.defines().index(t.rep.name)
         except ValueError:
-            print "{} : {} : {}".format(sort,sort.defines(),t.rep)
+            print("{} : {} : {}".format(sort,sort.defines(),t.rep))
             exit(1)
         return binenc(m,n)
     elif isinstance(t,ivy_logic.Variable):
@@ -1470,12 +1470,12 @@ def encode_term(t,n,sort):
 #        return [atom_to_z3(ivy_logic.Atom(t.rep + ':' + str(n-1-i),t.args))
 #                for i in range(n)]
         args = [term_to_z3(arg) for arg in t.args]
-        print "encode_term t={}".format(t)
+        print("encode_term t={}".format(t))
         sig = ivy_logic.RelationSort(t.rep.sort.dom).to_z3()
 
         res = [apply_z3_func(z3_function(t.rep.name + ':' + str(n-1-i),sig),args)
                for i in range(n)]
-        print "encode_term res={}".format(res)
+        print("encode_term res={}".format(res))
         return res
 
 def encode_equality(*terms):
@@ -1534,4 +1534,4 @@ if __name__ == '__main__':
         ivy_logic.sig.constructors.add(t)
     add_symbol('f',ivy_logic.FunctionSort([ivy_logic.universe],s))
     cls = to_clauses("f(x) = a & f(y) = b")
-    print clauses_model_to_clauses(cls)
+    print(clauses_model_to_clauses(cls))

--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -24,10 +24,25 @@ from . import logic as lg
 
 import sys
 
-# Following accounts for Z3 API symbols that are hidden as of Z3-4.5.0
+# These symbols exist in the z3 module within the z3 package. At some point they
+# were hidden from re-export, making us have to reach into z3.z3 to get
+# them. And in python3 the semantics of imports changed, so we have to do an
+# even more awkward importlib contortion here to get at them.
+#
+# This last part seems unintentional and there's a fix filed upstream to correct
+# it eventually: https://github.com/Z3Prover/z3/pull/5079
 
-z3_to_ast_array = z3._to_ast_array if '_to_ast_array' in z3.__dict__ else z3.z3._to_ast_array
-z3_to_expr_ref = z3._to_expr_ref if '_to_expr_ref' in z3.__dict__ else z3.z3._to_expr_ref
+if '_to_ast_array' in z3.__dict__ and '_to_expr_ref' in z3.__dict__:
+    z3_to_ast_array = z3._to_ast_array
+    z3_to_expr_ref = z3._to_expr_ref
+elif '_to_ast_array' in z3.z3.__dict__ and '_to_expr_ref' in z3.z3.__dict__:
+    z3_to_ast_array = z3.z3._to_ast_array
+    z3_to_expr_ref = z3.z3._to_expr_ref
+else:
+    import importlib
+    z3z3 = importlib.import_module("z3.z3", package="z3")
+    z3_to_ast_array = z3z3._to_ast_array
+    z3_to_expr_ref = z3z3._to_expr_ref
 
 use_z3_enums = True
 

--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -665,6 +665,25 @@ def get_arg_range(m,x):
 
 import itertools
 
+def cmp_to_key(mycmp):
+    'Convert a cmp= function into a key= function'
+    class K:
+        def __init__(self, obj, *args):
+            self.obj = obj
+        def __lt__(self, other):
+            return mycmp(self.obj, other.obj) < 0
+        def __gt__(self, other):
+            return mycmp(self.obj, other.obj) > 0
+        def __eq__(self, other):
+            return mycmp(self.obj, other.obj) == 0
+        def __le__(self, other):
+            return mycmp(self.obj, other.obj) <= 0
+        def __ge__(self, other):
+            return mycmp(self.obj, other.obj) >= 0
+        def __ne__(self, other):
+            return mycmp(self.obj, other.obj) != 0
+    return K
+
 class SortOrder(object):
     def __init__(self,vs,order,model):
         self.vs = vs
@@ -738,7 +757,7 @@ class HerbrandModel(object):
             fun = z3.Function
             self.model[order.to_z3()]
 #            print "sorting..."
-            elems = sorted(elems,SortOrder(z3_vs,order_atom,self.model))
+            elems = sorted(elems,key=cmp_to_key(SortOrder(z3_vs,order_atom,self.model)))
         except IndexError:
             pass
 #        print "elems: {}".format(map(str,elems))

--- a/ivy/ivy_tactics.py
+++ b/ivy/ivy_tactics.py
@@ -2,14 +2,14 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_proof as pf
-import ivy_actions as ia
-import ivy_temporal as tm
-import ivy_logic as lg
-import ivy_utils as iu
-import ivy_trace as tr
-import ivy_logic_utils as lu
-import ivy_proof as pr
+from . import ivy_proof as pf
+from . import ivy_actions as ia
+from . import ivy_temporal as tm
+from . import ivy_logic as lg
+from . import ivy_utils as iu
+from . import ivy_trace as tr
+from . import ivy_logic_utils as lu
+from . import ivy_proof as pr
 
 # This tactic reduces a safety property to initiatation and consecution
 # subgoals. TODO: we lose the annotation here, so we can't extract a

--- a/ivy/ivy_temporal.py
+++ b/ivy/ivy_temporal.py
@@ -114,12 +114,12 @@
 # step occurs) or upon exit from the operator's environment (i.e., after a
 # call statement into the environment from the outside.
 
-import ivy_logic as il
-import ivy_ast as ia
-import ivy_proof as ipr
-import ivy_utils as iu
-import ivy_actions as iact
-import ivy_logic_utils as ilu
+from . import ivy_logic as il
+from . import ivy_ast as ia
+from . import ivy_proof as ipr
+from . import ivy_utils as iu
+from . import ivy_actions as iact
+from . import ivy_logic_utils as ilu
 from collections import defaultdict
 
 class ActionTerm(ia.AST):
@@ -225,7 +225,7 @@ def new_action_to_old(act):
     return act.stmt
 
 def normal_program_from_module(mod):
-    bindings = [ActionTermBinding(name,old_action_to_new(act)) for name,act in mod.actions.iteritems()]
+    bindings = [ActionTermBinding(name,old_action_to_new(act)) for name,act in mod.actions.items()]
     init = iact.Sequence(*[action for actname,action in mod.initializers])
     invars = mod.labeled_conjs
     asms = mod.assumed_invariants
@@ -341,7 +341,7 @@ def invariance_tactic(prover,goals,proof):
         for sym in ilu.symbols_ast(prop):
             symprops[sym].append(prop)
     actions = dict((b.name,b.action) for b in model.bindings)
-    lines = dict(zip(gprops,gproplines))
+    lines = dict(list(zip(gprops,gproplines)))
             
     def instr_stmt(stmt,labels):
 
@@ -438,7 +438,7 @@ ipr.register_tactic('invariance',invariance_tactic)
 
 def implicit_tactic(prover,goals,proof):
     implicit_axioms = [x for x in prover.axioms if not x.explicit]
-    print 'temporal axioms: {}'.format([x.temporal for x in implicit_axioms])
+    print('temporal axioms: {}'.format([x.temporal for x in implicit_axioms]))
     goal,goals = goals[0],goals[1:]
     goal = ipr.goal_prefix_prems(goal,implicit_axioms,goal.lineno)
     return [goal]+goals

--- a/ivy/ivy_theory.py
+++ b/ivy/ivy_theory.py
@@ -1,9 +1,9 @@
-import ivy_actions as ia
-import ivy_module as im
-import ivy_logic as il
-import ivy_utils as iu
-import logic_util as lu
-import ivy_logic_utils as ilu
+from . import ivy_actions as ia
+from . import ivy_module as im
+from . import ivy_logic as il
+from . import ivy_utils as iu
+from . import logic_util as lu
+from . import ivy_logic_utils as ilu
 from collections import defaultdict
 from tarjan import tarjan
 from itertools import chain

--- a/ivy/ivy_to_cpp.py
+++ b/ivy/ivy_to_cpp.py
@@ -3,23 +3,23 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_init
-import ivy_logic as il
-import ivy_module as im
-import ivy_utils as iu
-import ivy_actions as ia
-import logic as lg
-import logic_util as lu
-import ivy_solver as slv
-import ivy_transrel as tr
-import ivy_logic_utils as ilu
-import ivy_compiler as ic
-import ivy_isolate as iso
-import ivy_ast
+from . import ivy_init
+from . import ivy_logic as il
+from . import ivy_module as im
+from . import ivy_utils as iu
+from . import ivy_actions as ia
+from . import logic as lg
+from . import logic_util as lu
+from . import ivy_solver as slv
+from . import ivy_transrel as tr
+from . import ivy_logic_utils as ilu
+from . import ivy_compiler as ic
+from . import ivy_isolate as iso
+from . import ivy_ast
 import itertools
-import ivy_cpp
-import ivy_cpp_types
-import ivy_fragment as ifc
+from . import ivy_cpp
+from . import ivy_cpp_types
+from . import ivy_fragment as ifc
 import sys
 import os
 
@@ -27,6 +27,7 @@ import os
 from collections import defaultdict
 from operator import mul
 import re
+from functools import reduce
 
 
 def all_state_symbols():
@@ -391,13 +392,13 @@ large_thresh = 1024
 def is_large_destr(sort):
     if hasattr(sort,'dom') and any(not is_any_integer_type(s) for s in sort.dom[1:]):
         return True
-    cards = map(sort_card,sort.dom[1:] if hasattr(sort,'dom') else [])
+    cards = list(map(sort_card,sort.dom[1:] if hasattr(sort,'dom') else []))
     return not(all(cards) and reduce(mul,cards,1) <= large_thresh)
 
 def is_large_type(sort):
     if hasattr(sort,'dom') and any(not is_any_integer_type(s) for s in sort.dom):
         return True
-    cards = map(sort_card,sort.dom if hasattr(sort,'dom') else [])
+    cards = list(map(sort_card,sort.dom if hasattr(sort,'dom') else []))
     return not(all(cards) and reduce(mul,cards,1) <= large_thresh)
 
 def is_large_lhs(term):
@@ -409,7 +410,7 @@ def is_large_lhs(term):
     
 
 def ctype_function(sort,classname=None,skip_params=0):
-    cards = map(sort_card,sort.dom[skip_params:] if hasattr(sort,'dom') else [])
+    cards = list(map(sort_card,sort.dom[skip_params:] if hasattr(sort,'dom') else []))
     cty = ctypefull(sort.rng,classname)
     if all(cards) and reduce(mul,cards,1) <= large_thresh:
         if not(hasattr(sort,'dom') and any(not is_any_integer_type(s) for s in sort.dom[skip_params:])):
@@ -542,7 +543,7 @@ def emit_cpp_sorts(header):
             destrs = im.module.sort_destructors[name]
             for destr in destrs:
                 declare_symbol(header,destr,skip_params=1)
-            header.append("        size_t __hash() const { "+struct_hash_fun(map(memname,destrs),[d.sort for d in destrs]) + "}\n")
+            header.append("        size_t __hash() const { "+struct_hash_fun(list(map(memname,destrs)),[d.sort for d in destrs]) + "}\n")
             header.append("    };\n");
         elif isinstance(il.sig.sorts[name],il.EnumeratedSort):
             sort = il.sig.sorts[name]
@@ -567,7 +568,7 @@ def emit_cpp_sorts(header):
 
 
 def emit_sorts(header):
-    for name,sort in il.sig.sorts.iteritems():
+    for name,sort in il.sig.sorts.items():
         if name == "bool":
             continue
         if name in il.sig.interp:
@@ -677,7 +678,7 @@ def emit_set_field(header,symbol,lhs,rhs,nvars=0):
     domain = sort.dom[1:]
     vs = variables(domain,start=nvars)
     open_loop(header,vs)
-    lhs1 = 'apply("'+sname+'"'+''.join(','+s for s in ([lhs]+map(var_to_z3_val,vs))) + ')'
+    lhs1 = 'apply("'+sname+'"'+''.join(','+s for s in ([lhs]+list(map(var_to_z3_val,vs)))) + ')'
     rhs1 = rhs + ''.join('[{}]'.format(varname(v)) for v in vs) + '.' + memname(symbol)
     if sort.rng.name in im.module.sort_destructors:
         destrs = im.module.sort_destructors[sort.rng.name]
@@ -895,7 +896,7 @@ def extract_defined_parameters(pre_clauses,inputs):
     inpdefs = []
     while change:
         change = False
-        for input,fmla in list(defmap.iteritems()):
+        for input,fmla in list(defmap.items()):
             if (all(input not in ilu.used_symbols_ast(f) or f == fmla for f in pre_clauses.fmlas)
                 and all(input not in ilu.used_symbols_ast(d) for d in pre_clauses.defs)):
                 pre_clauses = ilu.Clauses([f for f in pre_clauses.fmlas if f != fmla],pre_clauses.defs)
@@ -981,7 +982,7 @@ def minimal_field_references(fmla,inputs):
         return set(y for y in refs if all(not(lt(x,y)) for x in refs))
             
     recur(fmla)
-    res = dict((inp,get_minima(refs)) for inp,refs in res.iteritems())
+    res = dict((inp,get_minima(refs)) for inp,refs in res.items())
     return res
                 
 def minimal_field_siblings(inputs,mrefs):
@@ -1007,15 +1008,15 @@ def extract_input_fields(pre_clauses,inputs):
         if len(f.args) == 1:
             return field_symbol_name(f.args[0]) + '__' + f.rep.name
         return f.rep.name
-    fsyms = dict((il.Symbol(field_symbol_name(y),y.sort),y) for l in mrefs.values() for y in l)
-    rfsyms  = dict((y,x) for x,y in fsyms.iteritems())
+    fsyms = dict((il.Symbol(field_symbol_name(y),y.sort),y) for l in list(mrefs.values()) for y in l)
+    rfsyms  = dict((y,x) for x,y in fsyms.items())
     def recur(f):
         if il.is_app(f):
             if f.rep in mrefs or f.rep.name in im.module.destructor_sorts and len(f.args) == 1:
                 if f in rfsyms:
                     return rfsyms[f]
-        return f.clone(map(recur,f.args))
-    pre_clauses = ilu.Clauses(map(recur,pre_clauses.fmlas),map(recur,pre_clauses.defs))
+        return f.clone(list(map(recur,f.args)))
+    pre_clauses = ilu.Clauses(list(map(recur,pre_clauses.fmlas)),list(map(recur,pre_clauses.defs)))
     inputs = list(fsyms.keys())
     return pre_clauses,inputs,fsyms
 
@@ -1028,12 +1029,12 @@ def expand_field_references(pre_clauses):
     def recur(f):
         if il.is_app(f) and f.rep in defmap:
             return recur(defmap[f.rep])
-        return f.clone(map(recur,f.args))
+        return f.clone(list(map(recur,f.args)))
     def recur_def(d):
         return d.clone([d.args[0],recur(d.args[1])])
-    dfs = map(recur,pre_clauses.defs)
+    dfs = list(map(recur,pre_clauses.defs))
     dfs = [df for df in dfs if df.args[0] != df.args[1]]
-    return ilu.Clauses(map(recur,pre_clauses.fmlas),dfs)
+    return ilu.Clauses(list(map(recur,pre_clauses.fmlas)),dfs)
 
 def emit_action_gen(header,impl,name,action,classname):
     global indent_level
@@ -1190,7 +1191,7 @@ def emit_derived(header,impl,df,classname,inline=False):
     retval = il.Symbol("ret:val",sort)
     vs = df.args[0].args
     ps = [ilu.var_to_skolem('fml:',v) for v in vs]
-    mp = dict(zip(vs,ps))
+    mp = dict(list(zip(vs,ps)))
     rhs = ilu.substitute_ast(df.args[1],mp)
     action = ia.AssignAction(retval,rhs)
     action.formal_params = ps
@@ -1371,7 +1372,7 @@ def emit_param_decls(header,name,params,extra=[],classname=None,ptypes=None):
     header.append(funname(name) + '(')
     for p in params:
         if il.is_function_sort(p.sort):
-            raise(iu.IvyError(None,'Cannot compile parameter {} with function sort'.format(p)))
+            raise iu
     header.append(', '.join(extra + [ctype(p.sort,classname=classname,ptype = ptypes[idx] if ptypes else None) + ' ' + varname(p.name) for idx,p in enumerate(params)]))
     header.append(')')
 
@@ -1386,8 +1387,8 @@ def emit_param_decls_with_inouts(header,name,params,classname,ptypes,returns,ret
 
 def emit_method_decl(header,name,action,body=False,classname=None,inline=False):
     if not hasattr(action,"formal_returns"):
-        print "bad name: {}".format(name)
-        print "bad action: {}".format(action)
+        print("bad name: {}".format(name))
+        print("bad action: {}".format(action))
     rs = action.formal_returns
     ptypes,rtypes = get_param_types(name,action)
     if not body:
@@ -1594,7 +1595,7 @@ def emit_tick(header,impl,classname):
                 continue
             rvs = list(lu.free_variables(r.args[0]))
             assert len(rvs) == len(vs)
-            subs = dict(zip(rvs,vs))
+            subs = dict(list(zip(rvs,vs)))
 
             ## TRICKY: If there are any free variables on rhs of
             ## rely not occuring on left, we must prevent their capture
@@ -1633,7 +1634,7 @@ def csortcard(s):
     return str(card) if card else "0"
 
 def check_member_names(classname):
-    names = map(varname,(list(il.sig.symbols) + list(il.sig.sorts) + list(im.module.actions)))
+    names = list(map(varname,(list(il.sig.symbols) + list(il.sig.sorts) + list(im.module.actions))))
     if classname in names:
         raise iu.IvyError(None,'Cannot create C++ class {} with member {}.\nUse command line option classname=... to change the class name.'
                           .format(classname,classname))
@@ -1711,7 +1712,7 @@ def module_to_cpp_class(classname,basename):
     is_derived = dict()
     for ldf in im.module.definitions + im.module.native_definitions:
         is_derived[ldf.formula.defines()] = ldf
-    for sortname, conss in im.module.sort_constructors.iteritems():
+    for sortname, conss in im.module.sort_constructors.items():
         for cons in conss:
             is_derived[cons] = True
     global cpptypes
@@ -1720,7 +1721,7 @@ def module_to_cpp_class(classname,basename):
     sort_to_cpptype = {}
     global field_names
     field_names = dict()
-    for destrs in im.module.sort_destructors.values():
+    for destrs in list(im.module.sort_destructors.values()):
         if destrs: # paranoia
             dest_base,_ = iu.parent_child_name(destrs[0].name)
             if not all(iu.parent_child_name(d.name)[0] == dest_base for d in destrs):
@@ -1731,7 +1732,7 @@ def module_to_cpp_class(classname,basename):
         for t in list(il.sig.interp):
             attr = iu.compose_names(t,'override')
             if attr in im.module.attributes:
-                print 'override: interpreting {} as {}'.format(t,im.module.attributes[attr].rep)
+                print('override: interpreting {} as {}'.format(t,im.module.attributes[attr].rep))
                 il.sig.interp[t] = im.module.attributes[attr].rep
 
     global number_format
@@ -2050,7 +2051,7 @@ void CLASSNAME::install_timer(timer *r) {
     native_exprs = []
     for n in im.module.natives:
         native_exprs.extend(n.args[2:])
-    for actn,actb in im.module.actions.iteritems():
+    for actn,actb in im.module.actions.items():
         for n in actb.iter_subactions():
             if isinstance(n,ia.NativeAction):
                 native_exprs.extend(n.args[1:])
@@ -2625,7 +2626,7 @@ class z3_thunk : public thunk<D,R> {
     for ldf in im.module.definitions + im.module.native_definitions:
         with ivy_ast.ASTContext(ldf):
             emit_derived(header,impl,ldf.formula,classname)
-    for sortname, conss in im.module.sort_constructors.iteritems():
+    for sortname, conss in im.module.sort_constructors.items():
         for cons in conss:
             emit_constructor(header,impl,cons,classname)
     for native in im.module.natives:
@@ -2728,7 +2729,7 @@ class z3_thunk : public thunk<D,R> {
         if target.get() == "gen":
             emit_boilerplate1(sf,impl,classname)
         emit_init_gen(sf,impl,classname)
-        for name,action in im.module.actions.iteritems():
+        for name,action in im.module.actions.items():
             if name in im.module.public_actions:
                 emit_action_gen(sf,impl,name,action,classname)
 
@@ -2747,7 +2748,7 @@ class z3_thunk : public thunk<D,R> {
         # Tricky: inlines for for supertypes have to come *after* the inlines
         # for the subtypes. So we re-sort the types accordingly.
         arcs = [(x,s) for s in im.module.sort_order for x in im.sort_dependencies(im.module,s,with_variants=True)]
-        variant_of = set((x.name,y) for y,l in im.module.variants.iteritems() for x in l)
+        variant_of = set((x.name,y) for y,l in im.module.variants.items() for x in l)
         arcs = [a for a in arcs if a in variant_of]
         inline_sort_order = iu.topological_sort(im.module.sort_order,arcs)
         global_classname = classname
@@ -3189,7 +3190,7 @@ def assign_symbol_value(header,lhs_text,m,v,same=False):
                     assign_symbol_value(header,lhs_text+[ctext],m,term,same)
                     close_loop(header,vs)
                 else:
-                    for args in itertools.product(*[range(sort_card(s)) for s in dom]):
+                    for args in itertools.product(*[list(range(sort_card(s))) for s in dom]):
                         term = sym(*([v] + [il.Symbol(str(a),s) for a,s in zip(args,dom)]))
                         ctext = memname(sym) + ''.join('['+str(a)+']' for a in args)
                         assign_symbol_value(header,lhs_text+[ctext],m,term,same)
@@ -3210,7 +3211,7 @@ def assign_symbol_from_model(header,sym,m):
     really_check_representable(sym)
     fun = lambda v: cstr(m.eval_to_constant(v))
     if hasattr(sort,'dom'):
-        for args in itertools.product(*[range(sort_card(s)) for s in sym.sort.dom]):
+        for args in itertools.product(*[list(range(sort_card(s))) for s in sym.sort.dom]):
             term = sym(*[il.Symbol(str(a),s) for a,s in zip(args,sym.sort.dom)])
             ctext = varname(sym.name) + ''.join('['+str(a)+']' for a in args)
             assign_symbol_value(header,[ctext],fun,term)
@@ -3251,7 +3252,7 @@ def emit_one_initial_state(header):
 #    clauses = ilu.and_clauses(im.module.init_cond,im.module.background_theory())
     m = slv.get_model_clauses(clauses)
     if m == None:
-        print clauses
+        print(clauses)
         if iu.version_le(iu.get_string_version(),"1.6"):
             raise iu.IvyError(None,'Initial condition and/or axioms are inconsistent')
         else:
@@ -3598,7 +3599,7 @@ def emit_quant(variables,body,header,code,exists=False):
         if iter_sort_name not in il.sig.sorts:
             iter_sort_name = iu.compose_names(iter,'t')
         if iter_sort_name not in il.sig.sorts:
-            print iter_sort_name
+            print(iter_sort_name)
             raise iu.IvyError(None,'sort {} has iterable attribute but no iterator'.format(v0.sort))
         iter_sort = il.sig.sorts[iter_sort_name]
         zero = []
@@ -3661,7 +3662,7 @@ def emit_some(self,header,code):
                 return
             
         vs = [il.Variable('X__'+str(idx),p.sort) for idx,p in enumerate(self.params())]
-        subst = dict(zip(self.params(),vs))
+        subst = dict(list(zip(self.params(),vs)))
         fmla = ilu.substitute_constants_ast(self.fmla(),subst)
         params = self.params()
     else:
@@ -3876,8 +3877,8 @@ def emit_assign(self,header):
 ia.AssignAction.emit = emit_assign
 
 def emit_havoc(self,header):
-    print self
-    print self.lineno
+    print(self)
+    print(self.lineno)
     assert False
 
 ia.HavocAction.emit = emit_havoc
@@ -5165,7 +5166,7 @@ def main_int(is_ivyc):
                 raise iu.IvyError(None,'Version 2 compiler supports only target=repl')
             cdir = os.path.join(os.path.dirname(__file__), 'ivy2/s3')
             cmd = 'IVY_INCLUDE_PATH={} {} {}'.format(os.path.join(cdir,'include'),os.path.join(cdir,'ivyc_s3'),sys.argv[1])
-            print cmd
+            print(cmd)
             sys.stdout.flush()
             status = os.system(cmd)
             exit(status)
@@ -5188,7 +5189,7 @@ def main_int(is_ivyc):
                 if target.get() == 'test':
                     isolates = ['this']
                 else:
-                    extracts = list((x,y) for x,y in im.module.isolates.iteritems()
+                    extracts = list((x,y) for x,y in im.module.isolates.items()
                                     if isinstance(y,ivy_ast.ExtractDef))
                     if len(extracts) == 0:
                         isol = ivy_ast.ExtractDef(ivy_ast.Atom('extract'),ivy_ast.Atom('this'))
@@ -5222,14 +5223,14 @@ def main_int(is_ivyc):
 
 
                     def do_cmd(cmd):
-                        print cmd
+                        print(cmd)
                         status = os.system(cmd)
                         if status:
                             exit(1)
     
                     if isolate:
                         if len(isolates) > 1:
-                            print "Compiling isolate {}...".format(isolate)
+                            print("Compiling isolate {}...".format(isolate))
 
                     if (not iu.version_le(iu.get_string_version(),"1.6") and
                         target.get() == 'repl' and isolate in im.module.isolates):
@@ -5280,10 +5281,10 @@ def main_int(is_ivyc):
                             exit(1)
                     else:
                         libs = []    
-                    cpp11 = any(x.endswith('.cppstd') and y.rep=='cpp11' for x,y in im.module.attributes.iteritems())
+                    cpp11 = any(x.endswith('.cppstd') and y.rep=='cpp11' for x,y in im.module.attributes.items())
                     gpp11_spec = ' -std=c++11 ' if cpp11 else '' 
                     libspec = ''
-                    for x,y in im.module.attributes.iteritems():
+                    for x,y in im.module.attributes.items():
                         p,c = iu.parent_child_name(x)
                         if c == 'libspec':
                             if platform.system() == 'Windows':
@@ -5303,8 +5304,8 @@ def main_int(is_ivyc):
                         incspec = '/I {}'.format(os.path.join(_dir,'include'))
                         libpspec = '/LIBPATH:{}'.format(os.path.join(_dir,'lib'))
                         if not os.path.exists('libz3.dll'):
-                            print 'Copying libz3.dll to current directory.'
-                            print 'If the binary {}.exe is moved to another directory, this file must also be moved.'.format(basename)
+                            print('Copying libz3.dll to current directory.')
+                            print('If the binary {}.exe is moved to another directory, this file must also be moved.'.format(basename))
                             do_cmd('copy {} libz3.dll'.format(os.path.join(_dir,'lib','libz3.dll')))
                         for lib in libs:
                             _incdir = lib[1] if len(lib) >= 2 else []
@@ -5346,7 +5347,7 @@ def main_int(is_ivyc):
                             cmd = cmd + ' -lz3'
                         cmd += libspec
                         cmd += ' -pthread'
-                    print cmd
+                    print(cmd)
                     sys.stdout.flush()
                     with iu.WorkingDir(builddir):
                         status = os.system(cmd)

--- a/ivy/ivy_to_cpp.py
+++ b/ivy/ivy_to_cpp.py
@@ -67,7 +67,7 @@ def get_indent(line):
         if char == ' ':
             lindent += 1
         elif char == '\t':
-            lindent = (lindent + 8) / 8 * 8
+            lindent = (lindent + 8) // 8 * 8
         else:
             break
     return lindent

--- a/ivy/ivy_to_cpp.py
+++ b/ivy/ivy_to_cpp.py
@@ -1212,8 +1212,8 @@ def emit_constructor(header,impl,cons,classname,inline=False):
     emit_some_action(header,impl,name,action,classname,inline)
 
 
-def native_split(string):
-    split = string.split('\n',1)
+def native_split(s):
+    split = s.split('\n',1)
     if len(split) == 2:
         tag = split[0].strip()
         return ("member" if not tag else tag),split[1]

--- a/ivy/ivy_to_lean.py
+++ b/ivy/ivy_to_lean.py
@@ -1,17 +1,17 @@
 # coding: utf-8
-import ivy_init
-import ivy_logic as il
-import ivy_module as im
-import ivy_utils as iu
-import ivy_actions as ia
-import logic as lg
-import logic_util as lu
-import ivy_logic_utils as ilu
-import ivy_compiler as ic
-import ivy_isolate as iso
-import ivy_ast
+from . import ivy_init
+from . import ivy_logic as il
+from . import ivy_module as im
+from . import ivy_utils as iu
+from . import ivy_actions as ia
+from . import logic as lg
+from . import logic_util as lu
+from . import ivy_logic_utils as ilu
+from . import ivy_compiler as ic
+from . import ivy_isolate as iso
+from . import ivy_ast
 import itertools
-import ivy_theory as ith
+from . import ivy_theory as ith
 
 things = []
 
@@ -161,14 +161,14 @@ def main():
             emit_symbol_def(sym)
         emit('def P := (PL.prog.letrec')
         emit_eol()
-        for name,act in im.module.actions.iteritems():
+        for name,act in im.module.actions.items():
             emit('  (@bndng.cons PL.pterm ("'+name+'",\n')
             emit_action(act)
             emit_eol()
             emit('    ) ')
             emit_eol()
         emit('  (bndng.default PL.pterm.skip)')
-        for name,act in im.module.actions.iteritems():
+        for name,act in im.module.actions.items():
             emit(')')
         emit_eol()
         exports = sorted(list(im.module.public_actions))

--- a/ivy/ivy_to_md.py
+++ b/ivy/ivy_to_md.py
@@ -1,12 +1,12 @@
 import sys
 import xml
 import xml.etree.ElementTree as ET
-import StringIO
+import io
 
 def main():
 
     if len(sys.argv) != 2 or not sys.argv[1].endswith('.ivy'):
-        print 'usage: {} <file>.ivy'.format(sys.argv[0])
+        print('usage: {} <file>.ivy'.format(sys.argv[0]))
 
     inpname = sys.argv[1]
     outname = inpname[:-3]+'md'
@@ -15,13 +15,13 @@ def main():
         with open(inpname) as f:
             content = f.readlines()
     except IOError:
-        print 'file {} not found'.format(inpname)
+        print('file {} not found'.format(inpname))
         exit(1)
 
     try:
         outf = open(outname,'w')
     except:
-        print 'could not open {} for output'.format(outname)
+        print('could not open {} for output'.format(outname))
 
 
     last_was_comment = True

--- a/ivy/ivy_trace.py
+++ b/ivy/ivy_trace.py
@@ -5,16 +5,16 @@
 #  Construct counterexample traces suitable for viewing with the GUI
 #
 
-import ivy_solver as islv
-import ivy_art as art
-import ivy_interp as itp
-import ivy_actions as act
-import ivy_logic as lg
-import ivy_transrel as itr
-import ivy_logic_utils as lut
-import ivy_utils as iu
-import ivy_module as im
-import ivy_solver as slv
+from . import ivy_solver as islv
+from . import ivy_art as art
+from . import ivy_interp as itp
+from . import ivy_actions as act
+from . import ivy_logic as lg
+from . import ivy_transrel as itr
+from . import ivy_logic_utils as lut
+from . import ivy_utils as iu
+from . import ivy_module as im
+from . import ivy_solver as slv
 from collections import defaultdict
 
 ################################################################################
@@ -79,7 +79,7 @@ class TraceBase(art.AnalysisGraph):
                 lines.append('\n')
             foo = False
             for c in state.clauses.fmlas:
-                s1,s2 = map(str,c.args)
+                s1,s2 = list(map(str,c.args))
                 if not(s1 in hash and hash[s1] == s2):
                     hash[s1] = s2
                     if not foo:
@@ -172,7 +172,7 @@ class Trace(TraceBase):
         for sym in self.vocab:
             if sym not in env and not itr.is_new(sym) and not self.is_skolem(sym):
                 sym_pairs.append((sym,sym))
-        for sym,renamed_sym in env.iteritems():
+        for sym,renamed_sym in env.items():
             if not itr.is_new(sym) and not self.is_skolem(sym):
                 sym_pairs.append((sym,renamed_sym))
         self.new_state_pairs(sym_pairs,env)
@@ -277,7 +277,7 @@ def make_vc(action,precond=[],postcond=[],check_asserts=True):
     clauses = lut.and_clauses(clauses,axioms)
     fc = lut.Clauses([lf.formula for lf in postcond])
     fc.annot = act.EmptyAnnotation()
-    used_names = frozenset(x.name for x in lg.sig.symbols.values())
+    used_names = frozenset(x.name for x in list(lg.sig.symbols.values()))
     def witness(v):
         c = lg.Symbol('@' + v.name, v.sort)
         assert c.name not in used_names

--- a/ivy/ivy_transrel.py
+++ b/ivy/ivy_transrel.py
@@ -28,18 +28,18 @@ that all symbols *not* in S are preserved.
 
 """
 
-from ivy_utils import UniqueRenamer, union_to_list, list_union, list_diff, IvyError, inverse_map, compose_maps, pretty
-from ivy_logic import Variable, Constant, Literal, Atom, Not, And, Or,App, RelationSort, Definition, is_prenex_universal
-from ivy_logic_utils import symbols_clauses, used_symbols_clauses, rename_clauses, clauses_using_symbols, simplify_clauses,\
+from .ivy_utils import UniqueRenamer, union_to_list, list_union, list_diff, IvyError, inverse_map, compose_maps, pretty
+from .ivy_logic import Variable, Constant, Literal, Atom, Not, And, Or,App, RelationSort, Definition, is_prenex_universal
+from .ivy_logic_utils import symbols_clauses, used_symbols_clauses, rename_clauses, clauses_using_symbols, simplify_clauses,\
     used_variables_clauses, used_constants_clauses, substitute_constants_clause, substitute_constants_clauses, constants_clauses,\
     relations_clauses, eq_lit, condition_clauses, or_clauses, ite_clauses, and_clauses, false_clauses, true_clauses,\
     formula_to_clauses, clauses_to_formula, formula_to_clauses_tseitin, is_ground_clause, \
     relations_clause, Clauses, sym_inst, negate_clauses, negate
-from ivy_solver import unsat_core, clauses_imply, clauses_imply_formula, clauses_sat, clauses_case, get_model_clauses, clauses_model_to_clauses, get_small_model
-import ivy_logic
-import ivy_logic_utils as lu
-import ivy_utils as iu
-from logic_util import is_tautology_equality
+from .ivy_solver import unsat_core, clauses_imply, clauses_imply_formula, clauses_sat, clauses_case, get_model_clauses, clauses_model_to_clauses, get_small_model
+from . import ivy_logic
+from . import ivy_logic_utils as lu
+from . import ivy_utils as iu
+from .logic_util import is_tautology_equality
 
 
 def new(sym):
@@ -228,7 +228,7 @@ def bind_olds_action(action):
 class CounterExample(object):
     def __init__(self,clauses):
         self.clauses = clauses
-    def __nonzero__(self):
+    def __bool__(self):
         return False
 
 def clauses_imply_formula_cex(clauses,fmla):
@@ -391,10 +391,10 @@ def hide_state_map(syms,update):
     return trmap, (new_updated,new_tr,new_pre)
 
 def subst_action(update,subst):
-    print subst
-    syms = dict(subst.iteritems())
+    print(subst)
+    syms = dict(iter(subst.items()))
     syms.update((new(s),new(syms[s])) for s in update[0] if s in syms)
-    print syms
+    print(syms)
     new_updated = [subst.get(s,s) for s in update[0]]
     new_tr = rename_clauses(update[1],syms)
     new_pre = rename_clauses(update[2],syms)
@@ -451,7 +451,7 @@ def extract_pre_post_model(clauses,model,updated):
     ignore = lambda s: s.is_skolem() or (not is_new(s) and s in renaming)
     post_clauses = clauses_model_to_clauses(clauses,ignore = ignore,model = model,numerals=use_numerals())
     post_clauses = rename_clauses(post_clauses,inverse_map(renaming))
-    return map(remove_taut_eqs_clauses,(pre_clauses,post_clauses))
+    return list(map(remove_taut_eqs_clauses,(pre_clauses,post_clauses)))
 
 def compose_state_action(state,axioms,action, check=True):
     """ Compose a state and an action, returning a state """

--- a/ivy/ivy_ui.py
+++ b/ivy/ivy_ui.py
@@ -1,20 +1,20 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_interp import *
-from ivy_graph import *
+from .ivy_interp import *
+from .ivy_graph import *
 from string import *
 import copy
 import functools
 import pickle
-from ivy_concept_space import clauses_to_concept
-import ivy_actions
-import ivy_graph_ui
-import ivy_alpha
-from ivy_art import AnalysisGraph, AnalysisSubgraph
-from ivy_graph_ui import GraphWidget
-import ivy_ui_util as uu
-import ivy_utils as iu
+from .ivy_concept_space import clauses_to_concept
+from . import ivy_actions
+from . import ivy_graph_ui
+from . import ivy_alpha
+from .ivy_art import AnalysisGraph, AnalysisSubgraph
+from .ivy_graph_ui import GraphWidget
+from . import ivy_ui_util as uu
+from . import ivy_utils as iu
 
 # Following is a hint to center window. Needs more research.
 # from tkinter import *
@@ -177,7 +177,7 @@ class AnalysisGraphUI(object):
         g = self.g
         covering_node = self.get_mark()
         if covering_node is not None:
-            print "Trying to cover %s by %s" % (covered_node.id,covering_node.id)
+            print("Trying to cover %s by %s" % (covered_node.id,covering_node.id))
             with self.ui_parent.run_context():
                 if not g.cover(covered_node,covering_node):
                     raise IvyError(None,"Covering failed")
@@ -224,19 +224,19 @@ class AnalysisGraphUI(object):
     def do_state_action(self,a,node=None):
         with self.ui_parent.run_context():
             with EvalContext(check=False):
-                print "action {"
+                print("action {")
                 s = self.g.do_state_action(a,self.get_alpha())
-                print "state = {}".format(s)
-                print "} action %s" % a.args[0]
+                print("state = {}".format(s))
+                print("} action %s" % a.args[0])
         self.rebuild()
 
     # Evaluate an action at a node
 
     def execute_action(self,n,a):
         with self.ui_parent.run_context():
-            print "action %s {" % a
+            print("action %s {" % a)
             s = self.g.execute_action(a,n,self.get_alpha())
-            print "} action %s" % a
+            print("} action %s" % a)
         self.rebuild()
 
     # Display the reached states tree
@@ -467,7 +467,7 @@ class AnalysisGraphUI(object):
 
     def reverse_goal(self, state, clauses):
         if state.pred != None:
-            print "reverse from %s to %s: post_state = %s" % (state.id,state.pred.id,clauses)
+            print("reverse from %s to %s: post_state = %s" % (state.id,state.pred.id,clauses))
             next_state = state.pred
             clauses = reverse_update_concrete_clauses(state,clauses)
             return (clauses,state.pred)
@@ -563,7 +563,7 @@ class IvyUI(object):
             cmd = lambda idx: self.try_property(udc[idx])
             self.listbox_dialog(msg,udc_text,command=cmd)
         else:
-            print "type(prop) = {}".format(type(prop))
+            print("type(prop) = {}".format(type(prop)))
             if hasattr(prop,'lineno'):
                 filename,lineno = prop.lineno
                 self.browse(filename,lineno)

--- a/ivy/ivy_ui_cti.py
+++ b/ivy/ivy_ui_cti.py
@@ -1,16 +1,16 @@
-import ivy_ui
-import ivy_logic as il
-import logic as lg
-from ivy_interp import State,EvalContext,reverse,decompose_action_app, universe_constraint
-import ivy_module as im
-import ivy_logic_utils as ilu
-import logic_util as lu
-import ivy_utils as iu
-import ivy_graph_ui
-import ivy_actions as ia
-import ivy_trace
+from . import ivy_ui
+from . import ivy_logic as il
+from . import logic as lg
+from .ivy_interp import State,EvalContext,reverse,decompose_action_app, universe_constraint
+from . import ivy_module as im
+from . import ivy_logic_utils as ilu
+from . import logic_util as lu
+from . import ivy_utils as iu
+from . import ivy_graph_ui
+from . import ivy_actions as ia
+from . import ivy_trace
 
-from concept import (get_initial_concept_domain,
+from .concept import (get_initial_concept_domain,
                      get_diagram_concept_domain,
                      get_structure_concept_domain,
                      get_structure_concept_abstract_value,
@@ -65,15 +65,15 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
         return ConceptGraphUI
 
     def new_ag(self):
-        from ivy_art import AnalysisGraph
+        from .ivy_art import AnalysisGraph
         ag = AnalysisGraph()
         return ag
 
     def autodetect_transitive(self):
-        import logic as lg
-        from ivy_logic_utils import Clauses
-        from ivy_solver import clauses_imply
-        from concept import Concept
+        from . import logic as lg
+        from .ivy_logic_utils import Clauses
+        from .ivy_solver import clauses_imply
+        from .concept import Concept
 
 #        self.edge_display_checkboxes['=']['transitive'].value = True
 #        self.edge_display_checkboxes['=']['all_to_all'].value = True
@@ -104,12 +104,12 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
 
 
     def check_inductiveness(self, button=None):
-        import ivy_transrel
-        from ivy_solver import get_small_model
-        from proof import ProofGoal
-        from ivy_logic_utils import Clauses, and_clauses, dual_clauses
+        from . import ivy_transrel
+        from .ivy_solver import get_small_model
+        from .proof import ProofGoal
+        from .ivy_logic_utils import Clauses, and_clauses, dual_clauses
         from random import randrange
-        from ivy_art import AnalysisGraph
+        from .ivy_art import AnalysisGraph
         
         with self.ui_parent.run_context():
 
@@ -123,7 +123,7 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
 #                conj = to_test.pop(randrange(len(to_test)))
                 conj = to_test.pop(0)
                 assert conj == None or conj.is_universal_first_order()
-                used_names = frozenset(x.name for x in il.sig.symbols.values())
+                used_names = frozenset(x.name for x in list(il.sig.symbols.values()))
                 def witness(v):
                     c = lg.Const('@' + v.name, v.sort)
                     assert c.name not in used_names
@@ -132,7 +132,7 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
                 # TODO: this is still a bit hacky, and without nice error reporting
                 if self.relations_to_minimize.value == 'relations to minimize':
                     self.relations_to_minimize.value = ' '.join(sorted(
-                        k for k, v in il.sig.symbols.iteritems()
+                        k for k, v in il.sig.symbols.items()
                         if (type(v.sort) is lg.FunctionSort and
                             v.sort.range == lg.Boolean and
                             v.name not in self.transitive_relations 
@@ -205,8 +205,8 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
         self.current_concept_graph.update()
 
     def diagram(self):
-        from ivy_solver import clauses_model_to_diagram, get_model_clauses
-        from ivy_transrel import is_skolem, reverse_image
+        from .ivy_solver import clauses_model_to_diagram, get_model_clauses
+        from .ivy_transrel import is_skolem, reverse_image
         if not self.have_cti:
             if self.check_inductiveness() or len(self.g.states) != 2:
                 return
@@ -230,7 +230,7 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
         self.cg = self.view_state(s0, reset=True)
         
     def show_result(self,res):
-        print res
+        print(res)
 
     def weaken(self, conjs = None, button=None):
         if conjs == None:
@@ -278,10 +278,10 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
             f.close()
 
     def bmc_conjecture(self, button=None, bound = None, conjecture=None, verbose=False, tell_unsat=True):
-        import ivy_transrel
-        import ivy_solver
-        from proof import ProofGoal
-        from ivy_logic_utils import Clauses, and_clauses, dual_clauses
+        from . import ivy_transrel
+        from . import ivy_solver
+        from .proof import ProofGoal
+        from .ivy_logic_utils import Clauses, and_clauses, dual_clauses
 
         # get the bound, if not specified
 
@@ -306,7 +306,7 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
                 conj = and_clauses(*self.conjectures)
             
             assert conj.is_universal_first_order()
-            used_names = frozenset(x.name for x in il.sig.symbols.values())
+            used_names = frozenset(x.name for x in list(il.sig.symbols.values()))
             def witness(v):
                 c = lg.Const('@' + v.name, v.sort)
                 assert c.name not in used_names
@@ -319,7 +319,7 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
                 ag.add_initial_state(ag.init_cond)
                 post = ag.states[0]
             if 'initialize' in im.module.actions:
-                print "got here"
+                print("got here")
                 init_action = im.module.actions['initialize']
                 post = ag.execute(init_action, None, None, 'initialize')
 
@@ -337,7 +337,7 @@ class AnalysisGraphUI(ivy_ui.AnalysisGraphUI):
                             n,
                             str(conj.to_formula()),
                         )
-                    print '\n' + msg + '\n'
+                    print('\n' + msg + '\n')
                 if res is not None:
     #                ta.step()
                     cmd = lambda: self.ui_parent.add(res,ui_class=ivy_ui.AnalysisGraphUI)
@@ -402,12 +402,12 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
 
         The result is a Clauses object
         """
-        from logic_util import used_constants, free_variables, substitute
-        from ivy_logic_utils import negate, Clauses, simplify_clauses
+        from .logic_util import used_constants, free_variables, substitute
+        from .ivy_logic_utils import negate, Clauses, simplify_clauses
 
         facts = self.get_active_facts()
         assert len(free_variables(*facts)) == 0, "conjecture would contain existential quantifiers..."
-        sig_symbols = frozenset(il.sig.symbols.values())
+        sig_symbols = frozenset(list(il.sig.symbols.values()))
         facts_consts = used_constants(*facts)
         subs = {}
         rn = iu.VariableGenerator()
@@ -453,7 +453,7 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
 
 
     def conjecture(self):
-        print self.get_selected_conjecture()
+        print(self.get_selected_conjecture())
 
 
     def bmc_conjecture(self, button=None, bound = None, conjecture=None, verbose=False, add_to_crg=True, tell_unsat=True):
@@ -466,12 +466,12 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
 
 
     def minimize_conjecture(self, button=None, bound=None):
-        import ivy_transrel
-        import ivy_solver
-        from proof import ProofGoal
-        from ivy_logic_utils import Clauses, and_clauses, dual_clauses, used_symbols_clauses, negate
-        from ivy_solver import unsat_core
-        from logic_util import free_variables, substitute
+        from . import ivy_transrel
+        from . import ivy_solver
+        from .proof import ProofGoal
+        from .ivy_logic_utils import Clauses, and_clauses, dual_clauses, used_symbols_clauses, negate
+        from .ivy_solver import unsat_core
+        from .logic_util import free_variables, substitute
 
         if self.bmc_conjecture(bound=bound,tell_unsat=False):
             # found a BMC counter-example
@@ -492,7 +492,7 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
             post_clauses = and_clauses(post.clauses, axioms)
 
             used_names = (
-                frozenset(x.name for x in il.sig.symbols.values()) |
+                frozenset(x.name for x in list(il.sig.symbols.values())) |
                 frozenset(x.name for x in used_symbols_clauses(post_clauses))
             )
             facts = self.get_active_facts()
@@ -521,10 +521,10 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
         TODO: this has a lot in common with check_inductiveness,
         should refactor common parts out
         """
-        import ivy_transrel
-        import ivy_solver
-        from proof import ProofGoal
-        from ivy_logic_utils import Clauses, and_clauses, dual_clauses
+        from . import ivy_transrel
+        from . import ivy_solver
+        from .proof import ProofGoal
+        from .ivy_logic_utils import Clauses, and_clauses, dual_clauses
         from random import randrange
 
         with self.ui_parent.run_context():
@@ -543,7 +543,7 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
             post.clauses = ilu.true_clauses(annot=ia.EmptyAnnotation())
 
             assert target_conj.is_universal_first_order()
-            used_names = frozenset(x.name for x in il.sig.symbols.values())
+            used_names = frozenset(x.name for x in list(il.sig.symbols.values()))
             def witness(v):
                 c = lg.Const('@' + v.name, v.sort)
                 assert c.name not in used_names
@@ -569,10 +569,10 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
         TODO: this has a lot in common with check_inductiveness and is_sufficient,
         should refactor common parts out
         """
-        import ivy_transrel
-        import ivy_solver
-        from proof import ProofGoal
-        from ivy_logic_utils import Clauses, and_clauses, dual_clauses
+        from . import ivy_transrel
+        from . import ivy_solver
+        from .proof import ProofGoal
+        from .ivy_logic_utils import Clauses, and_clauses, dual_clauses
         from random import randrange
 
         with self.ui_parent.run_context():
@@ -590,7 +590,7 @@ class ConceptGraphUI(ivy_graph_ui.GraphWidget):
             post.clauses = ilu.true_clauses(annot=ia.EmptyAnnotation())
 
             assert target_conj.is_universal_first_order()
-            used_names = frozenset(x.name for x in il.sig.symbols.values())
+            used_names = frozenset(x.name for x in list(il.sig.symbols.values()))
             def witness(v):
                 c = lg.Const('@' + v.name, v.sort)
                 assert c.name not in used_names

--- a/ivy/ivy_ui_util.py
+++ b/ivy/ivy_ui_util.py
@@ -1,10 +1,10 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from Tkinter import *
-import Tkconstants, tkFileDialog
-import Tix
-import ivy_utils as iu
+from tkinter import *
+import tkinter.constants, tkinter.filedialog
+import tkinter.tix
+from . import ivy_utils as iu
 import functools
 
 class MenuBar(Frame):
@@ -92,8 +92,8 @@ def center_window_on_window(toplevel,win):
     win = win.winfo_toplevel()
     toplevel.update_idletasks()
     wg = win.geometry().split('+')
-    wx,wy = map(int,wg[1:3])
-    wxs,wys = map(int,wg[0].split('x'))
+    wx,wy = list(map(int,wg[1:3]))
+    wxs,wys = list(map(int,wg[0].split('x')))
     xc = wx + wxs/2
     yc = wy + wys/2
     size = tuple(int(_) for _ in toplevel.geometry().split('+')[0].split('x'))
@@ -109,7 +109,7 @@ def destroy_then(dlg,command):
     return functools.partial(destroy_then_aux,dlg,command)
 
 def destroy_then_command_on_selection_aux(dlg,lbox,command,mult):
-    sel = map(int, lbox.curselection())
+    sel = list(map(int, lbox.curselection()))
     dlg.destroy()
     if sel:
         command(sel if mult else sel[0])

--- a/ivy/ivy_ui_util.py
+++ b/ivy/ivy_ui_util.py
@@ -84,8 +84,8 @@ def center_window(toplevel):
     w = toplevel.winfo_screenwidth()
     h = toplevel.winfo_screenheight()
     size = tuple(int(_) for _ in toplevel.geometry().split('+')[0].split('x'))
-    x = w/2 - size[0]/2
-    y = h/2 - size[1]/2
+    x = w//2 - size[0]//2
+    y = h//2 - size[1]//2
     toplevel.geometry("%dx%d+%d+%d" % (size + (x, y)))
 
 def center_window_on_window(toplevel,win):
@@ -94,11 +94,11 @@ def center_window_on_window(toplevel,win):
     wg = win.geometry().split('+')
     wx,wy = list(map(int,wg[1:3]))
     wxs,wys = list(map(int,wg[0].split('x')))
-    xc = wx + wxs/2
-    yc = wy + wys/2
+    xc = wx + wxs//2
+    yc = wy + wys//2
     size = tuple(int(_) for _ in toplevel.geometry().split('+')[0].split('x'))
-    x = xc - size[0]/2
-    y = yc - size[1]/2
+    x = xc - size[0]//2
+    y = yc - size[1]//2
     toplevel.geometry("%dx%d+%d+%d" % (size + (x, y)))
 
 def destroy_then_aux(dlg,command):

--- a/ivy/ivy_unitres.py
+++ b/ivy/ivy_unitres.py
@@ -1,12 +1,12 @@
 #
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
-from ivy_resolution import mgu_eq
-from ivy_logic import *
-from ivy_logic_utils import * 
-import ivy_congclos as congclos
+from .ivy_resolution import mgu_eq
+from .ivy_logic import *
+from .ivy_logic_utils import * 
+from . import ivy_congclos as congclos
 from collections import defaultdict
-import ivy_logic
+from . import ivy_logic
 
 def verbose():
     return False
@@ -162,7 +162,7 @@ def find_subsumed_rec(index, terms, idx):
         return
     t = terms[idx]
     if isinstance(t,Variable):
-        for x,sub_index in index[2].iteritems():
+        for x,sub_index in index[2].items():
             for y in find_subsumed_rec(sub_index, terms, idx+1):
                 yield y
     else:
@@ -189,7 +189,7 @@ def find_unifying_rec(index, terms, idx):
         return
     t = terms[idx]
     if isinstance(t,Variable) or t.rep.startswith('__v'):
-        for x,sub_index in index[2].iteritems():
+        for x,sub_index in index[2].items():
             for y in find_unifying_rec(sub_index, terms, idx+1):
                 yield y
     else:
@@ -285,7 +285,7 @@ class UnitRes(object):
                 self.unit_queue_gen.append(gen)
                 self.unit_ids.add(litid)
                 if verbose():
-                    print "added %s %s" % (lit,litid)
+                    print("added %s %s" % (lit,litid))
         else:
             i = len(self.clauses)
             self.clauses.append(cl)
@@ -305,7 +305,7 @@ class UnitRes(object):
                         new_rhs = substitute_constants_lit(rhs,subs)
                         if not lit_eq(rhs,new_rhs):
                             new_cl = [lhs,new_rhs]
-                            print "applied transitivity: %s" % cl
+                            print("applied transitivity: %s" % cl)
                             self.add_clause_basic(new_cl,gen)
 
     def update_equational_theory(self,lit):
@@ -314,7 +314,7 @@ class UnitRes(object):
             if isinstance(t0,Constant) and isinstance(t1,Constant):
                 equational_theory.union(t0,t1)
                 if verbose():
-                    print "merged %s %s" % (t0,t1)
+                    print("merged %s %s" % (t0,t1))
 
     def get_watching(self,lit):
         return index_lookup(self.index,lit)[1]
@@ -335,7 +335,7 @@ class UnitRes(object):
             if not isinstance(t,Variable) and t.rep not in used:
                 used.add(t.rep)
                 if any(lit_eq(self.unit_queue[j],self.unit_queue[i]) for j in self.unit_term_index[t.rep]):
-                    print "bad add: %s %s %s" % (self.unit_queue[i],i,self.unit_term_index[t.rep])
+                    print("bad add: %s %s %s" % (self.unit_queue[i],i,self.unit_term_index[t.rep]))
                     exit(1)
                 self.unit_term_index[t.rep].append(i)
         # also index units by their relation name
@@ -375,7 +375,7 @@ class UnitRes(object):
             if not new_specialization or is_unit:
                 return True
             if eqs and verbose():
-                print "spec: %s, %s -> %s" % (lit,other,eqs)
+                print("spec: %s, %s -> %s" % (lit,other,eqs))
             self.detected_specializations.extend(eqs)
         return not eqs
 
@@ -393,7 +393,7 @@ class UnitRes(object):
             if not lit_eq(lit2,lit3):
                 new_cl = [lit3]
                 if verbose():
-                    print "rewrite! %s,%s -> %s" % (lit,lit2,new_cl)
+                    print("rewrite! %s,%s -> %s" % (lit,lit2,new_cl))
                 new_gen = max(gen+1,self.unit_queue_gen[lit_idx])
                 self.add_clause(new_cl,new_gen)
                 if self.unsat:
@@ -402,7 +402,7 @@ class UnitRes(object):
         for lit_idx in self.unit_term_index[t1.rep]:
             lit2 = self.unit_queue[lit_idx]
             if verbose():
-                print "re-propagate: %s" % lit2
+                print("re-propagate: %s" % lit2)
             self.propagate_lit(lit2,max(gen+1,self.unit_queue_gen[lit_idx]))
             if self.unsat:
                 return
@@ -443,7 +443,7 @@ class UnitRes(object):
         #            print "cl: %s lit: %s" % (cl,lit)
                     lit2 = lit_rep(cl[j])
                     if lit2.polarity != 1-lit.polarity or lit2.atom.relname != lit.atom.relname:
-                        print "!!! %s %s %s %s %s" % (i,j,lit,lit2,cl)
+                        print("!!! %s %s %s %s %s" % (i,j,lit,lit2,cl))
                         exit(1)
                     if is_equality_lit(lit2) and all(isinstance(t,Variable) for t in lit2.atom.args):
                         continue
@@ -457,12 +457,12 @@ class UnitRes(object):
                         new_cl = [substitute_lit(lit1, subs) for k,lit1 in enumerate(cl) if k != j] + [Literal(0,eq) for eq in eqs]
                         if not new_specialization and not (specs == None):
                             if verbose():
-                                print "using specs: %s" % specs
+                                print("using specs: %s" % specs)
                             new_cl = substitute_constants_clause(new_cl,specs)
                         new_cl = simplify_clause(new_cl)
                         if not is_tautology(new_cl) and not self.subsumed_by_used_lit(lit,cl,new_cl):
                             if verbose():
-                                print "%s,%s -> %s" % (lit,cl,new_cl)
+                                print("%s,%s -> %s" % (lit,cl,new_cl))
                             new_gen = max(gen+1,self.clauses_gen[i])
                             self.add_clause(new_cl,new_gen)
                             if self.unsat:
@@ -491,7 +491,7 @@ class UnitRes(object):
                 new_cl = [Literal(0,eq) for eq in eqs]
                 if not self.subsumed_by_used_lit(lit,lit2,new_cl):
                     if verbose():
-                        print "units resolve! %s,%s -> %s" % (lit,lit2,new_cl)
+                        print("units resolve! %s,%s -> %s" % (lit,lit2,new_cl))
                     new_gen = max(gen+1,self.unit_queue_gen[lit_idx])
                     self.add_clause(new_cl,new_gen)
                     if self.unsat:
@@ -542,5 +542,5 @@ if __name__ == "__main__":
     r = UnitRes(to_clauses("p(U,v) & v = u & (~p(x,u) | q(u))"))
     with r.context():
         r.propagate()
-        print r.unit_queue
+        print(r.unit_queue)
 

--- a/ivy/ivy_utils.py
+++ b/ivy/ivy_utils.py
@@ -88,7 +88,7 @@ def unzip_append(tups):
 
 def unzip_pairs(tups):
     """ turn a list of pairs into a pair of lists """
-    return zip(*tups) if tups else ([],[])
+    return list(zip(*tups)) if tups else ([],[])
 
 def flatten(l):
     """ flatten a generator """
@@ -124,12 +124,12 @@ def distinct_unordered_pairs(l):
             yield (l[i],l[j])
 
 def inverse_map(m):
-    return dict((y,x) for x,y in m.iteritems())
+    return dict((y,x) for x,y in m.items())
 
 def compose_maps(m1,m2):
     """ compose two maps as functions. a map is assumed to be the identity for keys not present """
     res = m2.copy()
-    res.update((x,m2.get(y,y)) for x,y in m1.iteritems())
+    res.update((x,m2.get(y,y)) for x,y in m1.items())
     return res
 
 def partition(things,key):
@@ -279,7 +279,7 @@ class IvyError(Exception):
         self.lineno = ast.lineno if hasattr(ast,'lineno') else Location()
         self.msg = msg
         if not catch.get():
-            print str(self)
+            print(str(self))
             assert False
     def __str__(self):
         return str(self.lineno) + 'error: ' + self.msg
@@ -292,7 +292,7 @@ class IvyUndefined(IvyError):
         super(IvyUndefined,self).__init__(ast,"undefined: " + name)
 
 def warn(ast,msg):
-    print str(IvyError(ast,msg)).replace('error: ','warning: ')
+    print(str(IvyError(ast,msg)).replace('error: ','warning: '))
 
 # This module provides a generic parameter mechanism similar to
 # "parameterize" in racket. 
@@ -363,7 +363,7 @@ class Parameter(object):
         self.value = self.process(new_val)
         self.callback(self.value)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True if self.value else False
 
     def set_callback(self,callback):
@@ -425,7 +425,7 @@ def pairs_to_dict(pairs,key=lambda x:x):
     return d
 
 def dict_to_pairs(d):
-    return [(x,y) for x,l in d.iteritems() for y in l]
+    return [(x,y) for x,l in d.items() for y in l]
 
 def topological_sort(items,order,key=lambda x:x):
     """ items is a list, key maps list elements to hashable keys,
@@ -506,7 +506,7 @@ class ErrorPrinter(object):
         return self
     def __exit__(self,exc_type, exc_val, exc_tb):
         if exc_type == IvyError or isinstance(exc_val,IvyError):
-            print str(exc_val)
+            print(str(exc_val))
             exit(1)
             return True
         return False # don't block any other exceptions
@@ -560,7 +560,7 @@ def get_string_version():
     return ivy_language_version
 
 def string_version_to_numeric_version(v):
-    return map(int,string.split(v,'.'))
+    return list(map(int,string.split(v,'.')))
 
 def get_numeric_version():
     return string_version_to_numeric_version(ivy_language_version)
@@ -692,7 +692,7 @@ def dbg(*exprs):
         locs = frame.f_back.f_locals
         globs = frame.f_back.f_globals
         for e in exprs:
-            print "{}:{}".format(e,eval(e,globs,locs))
+            print("{}:{}".format(e,eval(e,globs,locs)))
     finally:
         del frame
 

--- a/ivy/ivy_utils.py
+++ b/ivy/ivy_utils.py
@@ -560,7 +560,7 @@ def get_string_version():
     return ivy_language_version
 
 def string_version_to_numeric_version(v):
-    return list(map(int,string.split(v,'.')))
+    return list(map(int,v.split('.')))
 
 def get_numeric_version():
     return string_version_to_numeric_version(ivy_language_version)

--- a/ivy/logic.py
+++ b/ivy/logic.py
@@ -6,8 +6,8 @@
 
 from operator import itemgetter
 
-from general import IvyError
-from utils.recstruct_object import recstruct
+from .general import IvyError
+from .utils.recstruct_object import recstruct
 
 # Exceptions
 
@@ -155,7 +155,7 @@ class Apply(recstruct('Apply', [], ['func', '*terms'])):
                          terms[i].sort != func.sort.domain[i] and
                          not any(type(t) is TopSort for t in (terms[i].sort, func.sort.domain[i]))]
             for i in bad_sorts:
-                print 'terms = {}'.format(terms)
+                print('terms = {}'.format(terms))
                 report_bad_sort(func,i,func.sort.domain[i],terms[i].sort)
         return (func, ) + terms
 
@@ -437,13 +437,13 @@ if __name__ == '__main__':
     assert contains_topsort(h)
 
     b = NamedBinder('mybinder', [X,Y,Z], None, Implies(And(f(X,Y), f(X,Z)), Eq(Y,Z)))
-    print b
-    print b.sort
-    print
+    print(b)
+    print(b.sort)
+    print()
 
     b = NamedBinder('mybinder', [X,Y,Z], None, Z)
-    print b
-    print b.sort
+    print(b)
+    print(b.sort)
 
 
     # TODO: add more tests, add tests for errors

--- a/ivy/logic_util.py
+++ b/ivy/logic_util.py
@@ -7,11 +7,11 @@
 from itertools import product, chain
 from functools import partial
 
-from logic import (Var, Const, Apply, Eq, Ite, Not, And, Or, Implies,
+from .logic import (Var, Const, Apply, Eq, Ite, Not, And, Or, Implies,
                    Iff, ForAll, Exists, Lambda, NamedBinder)
-from logic import contains_topsort
+from .logic import contains_topsort
 
-import ivy_utils as iu
+from . import ivy_utils as iu
 
 class CaptureError(Exception):
     def __init__(self,variables):
@@ -156,10 +156,10 @@ def substitute(t, subs):
         return type(t)(*(substitute(x, subs) for x in t))
 
     elif type(t) in (ForAll, Exists, Lambda, NamedBinder):
-        forbidden_variables = free_variables(*subs.values())
+        forbidden_variables = free_variables(*list(subs.values()))
         if forbidden_variables.isdisjoint(t.variables):
             return type(t)(t.variables, substitute(t.body, (
-                (k, v) for k, v in subs.iteritems()
+                (k, v) for k, v in subs.items()
                 if k not in t.variables
             )))
         else:
@@ -217,7 +217,7 @@ def substitute_apply(t, subs, by_name=False):
 
     elif type(t) in (ForAll, Exists, Lambda, NamedBinder):
         return type(t)(t.variables, _substitute_apply(t.body, subs=dict(
-            (k, v) for k, v in subs.iteritems()
+            (k, v) for k, v in subs.items()
             if k not in t.variables
         )))
     else:
@@ -265,7 +265,7 @@ def is_tautology_equality(t):
 
 
 if __name__ == '__main__':
-    from logic import *
+    from .logic import *
     s1 = UninterpretedSort('s1')
     s2 = UninterpretedSort('s2')
     X1 = Var('X', s1)

--- a/ivy/proof.py
+++ b/ivy/proof.py
@@ -8,9 +8,9 @@ process. It will later be split to multiple modules.
 
 from copy import deepcopy
 
-from ivy_compiler import ivy_load_file, ivy_new, IvyError
-from ivy_art import AnalysisGraph
-from ivy_utils import use_numerals
+from .ivy_compiler import ivy_load_file, ivy_new, IvyError
+from .ivy_art import AnalysisGraph
+from .ivy_utils import use_numerals
 
 class IvyModel(object):
     """
@@ -78,7 +78,7 @@ class AnalysisSession(object):
             (self.analysis_state, info)
          ))
         if 'msg' in info:
-            print info['msg']
+            print(info['msg'])
         if self.widget is not None:
             self.widget.step()
 

--- a/ivy/tactics.py
+++ b/ivy/tactics.py
@@ -6,8 +6,8 @@
 
 from textwrap import dedent
 
-import tactics_api as ta
-from tactics_api import (Tactic, tactic, arg_add_facts, push_goal,
+from . import tactics_api as ta
+from .tactics_api import (Tactic, tactic, arg_add_facts, push_goal,
                          arg_get_preds_action, implied_facts,
                          forward_image, arg_get_fact, get_diagram,
                          arg_initial_node, get_safety_property,
@@ -16,12 +16,12 @@ from tactics_api import (Tactic, tactic, arg_add_facts, push_goal,
                          remove_goal, arg_is_covered, arg_get_pred,
                          arg_preorder_traversal, arg_get_conjuncts,
                          goal_tactic)
-from ivy_logic_utils import negate_clauses, false_clauses
-from logic import Or, And
-from logic_util import normalize_quantifiers
-import ivy_alpha
-from z3_utils import z3_implies
-from interrupt_context import InterruptContext
+from .ivy_logic_utils import negate_clauses, false_clauses
+from .logic import Or, And
+from .logic_util import normalize_quantifiers
+from . import ivy_alpha
+from .z3_utils import z3_implies
+from .interrupt_context import InterruptContext
 
 
 @goal_tactic
@@ -260,7 +260,7 @@ class UPDR(Tactic):
 
                     if current_goal.node == init_frame:
                         # no invariant
-                        print "No Invariant!"
+                        print("No Invariant!")
                         return False
 
                     push_diagram(current_goal, False)
@@ -288,12 +288,12 @@ class UPDR(Tactic):
                     recalculate_facts(frames[i], list(facts_to_check))
 
             assert ic.interrupted
-            print "UPDR Interrupted by SIGINT"
+            print("UPDR Interrupted by SIGINT")
             return None
 
 
 if __name__ == '__main__':
-    from proof import AnalysisSession
+    from .proof import AnalysisSession
     #fn = '../src/ivy/test.ivy'
     fn = '../examples/ivy/client_server_sorted.ivy'
     #fn = '../examples/pldi16/leader_sorted.ivy'

--- a/ivy/tactics_api.py
+++ b/ivy/tactics_api.py
@@ -13,18 +13,18 @@ remains the same.
 import re
 import inspect
 
-from ivy_actions import ChoiceAction
-import ivy_transrel
-import ivy_solver
-from ivy_transrel import is_skolem
-import ivy_alpha
-from ivy_logic_utils import (and_clauses, formula_to_clauses,
+from .ivy_actions import ChoiceAction
+from . import ivy_transrel
+from . import ivy_solver
+from .ivy_transrel import is_skolem
+from . import ivy_alpha
+from .ivy_logic_utils import (and_clauses, formula_to_clauses,
                              clauses_to_formula, true_clauses,
                              false_clauses, negate_clauses, Clauses)
-from logic import And, Not
-from logic_util import normalize_quantifiers
-from proof import ProofGoal
-import ui_extensions_api
+from .logic import And, Not
+from .logic_util import normalize_quantifiers
+from .proof import ProofGoal
+from . import ui_extensions_api
 
 
 # class Facts(object):
@@ -111,7 +111,7 @@ def arg_add_action_node(pre, action, abstractor=None):
     Add a new node with an action edge from pre, and return it.
     """
     try:
-        label = [k for k, v in _ivy_ag.actions.iteritems() if v == action][0]
+        label = [k for k, v in _ivy_ag.actions.items() if v == action][0]
     except IndexError:
         label = None
     node = _ivy_ag.execute(action, pre, abstractor, label)
@@ -291,7 +291,7 @@ def refine_or_reverse(goal):
     axioms = _ivy_interp.background_theory()
     #import IPython
     #IPython.embed()
-    print "calling ivy_transrel.forward_interpolant"
+    print("calling ivy_transrel.forward_interpolant")
     x = ivy_transrel.forward_interpolant(
         pred.clauses,
         action.update(_ivy_interp, None),
@@ -299,7 +299,7 @@ def refine_or_reverse(goal):
         axioms,
         None,
     )
-    print "    got: {!r}".format(x)
+    print("    got: {!r}".format(x))
     if x is None:
         bi = backward_image(goal.formula, action)
         return False, goal_at_arg_node(bi, pred)
@@ -312,7 +312,7 @@ def implied_facts(premise, facts_to_check):
     Return a list of facts from facts_to_check that are implied by
     theory
     """
-    from z3_utils import z3_implies_batch
+    from .z3_utils import z3_implies_batch
     axioms = _ivy_interp.background_theory()
     premise = normalize_quantifiers((and_clauses(axioms, premise)).to_formula())
     facts_to_check = [f.to_formula() if type(f) is Clauses else f for f in facts_to_check]
@@ -334,7 +334,7 @@ def get_diagram(goal, weaken=False):
 
 
 def refuted_goal(goal):
-    from z3_utils import z3_implies
+    from .z3_utils import z3_implies
     axioms = _ivy_interp.background_theory()
     premise = (and_clauses(axioms, goal.node.clauses)).to_formula()
     f = Not(goal.formula.to_formula())
@@ -396,10 +396,10 @@ class Tactic(object):
         from IPython import embed
         set_context(self.analysis_session)
         # call pre hooks
-        print "Applying tactic: {}".format(type(self).__name__)
+        print("Applying tactic: {}".format(type(self).__name__))
         #embed()
         result = self.apply(*args, **kwargs)
-        print "Applying tactic: {} resulted in {}".format(type(self).__name__, result)
+        print("Applying tactic: {} resulted in {}".format(type(self).__name__, result))
         #embed()
         # call post hooks
         return result
@@ -454,7 +454,7 @@ def goal_tactic(tactic_cls):
 
 
 if __name__ == '__main__':
-    from proof import AnalysisSession
+    from .proof import AnalysisSession
 
     session = AnalysisSession('../src/ivy/test.ivy')
     set_context(session)

--- a/ivy/tk_cy.py
+++ b/ivy/tk_cy.py
@@ -2,14 +2,14 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_ui
-import ivy_ui_util as uu
-import ivy_utils as iu
-import ivy_graph_ui
-from cy_elements import *
-from Tkinter import *
-import Tkconstants, tkFileDialog
-import Tix
+from . import ivy_ui
+from . import ivy_ui_util as uu
+from . import ivy_utils as iu
+from . import ivy_graph_ui
+from .cy_elements import *
+from tkinter import *
+import tkinter.constants, tkinter.filedialog
+import tkinter.tix
 import functools
 
 # Functions for displaying a layed out CyElements graph in a Tk Canvas
@@ -47,7 +47,7 @@ def get_dimensions(element):
 # (x0,y0,x1,y1,...)
 
 def get_bspline(element):
-    bspline = map(get_coord,element['data']['bspline'])
+    bspline = list(map(get_coord,element['data']['bspline']))
     coords = []
     for p in bspline:
         coords.append(p[0])
@@ -131,7 +131,7 @@ class TkCyCanvas(Canvas):
                 self.tag_bind(eid, "<Button-1>", lambda y, elem=elem: self.click_edge("left",y,elem))
                 self.tag_bind(eid, "<Button-3>", lambda y, elem=elem: self.click_edge("right",y,elem))
             elif group == 'shapes':
-                coords = map(get_coord,get_coords(elem))
+                coords = list(map(get_coord,get_coords(elem)))
                 (x0,y0),(x1,y1) = coords
                 self.create_rectangle((x0,y0,x1,y1))
                     

--- a/ivy/tk_cy.py
+++ b/ivy/tk_cy.py
@@ -88,7 +88,7 @@ class TkCyCanvas(Canvas):
 
     def create_shape(self,shape,dimensions,**kwargs):
         x,y,w,h = dimensions
-        x0,y0,x1,y1 = x-w/2, y-h/2, x+w/2, y+h/2
+        x0,y0,x1,y1 = x-w//2, y-h//2, x+w//2, y+h//2
         method = {'ellipse':self.create_oval, 'oval':self.create_oval, 'octagon':self.create_octagon}[shape]
         if 'double' in kwargs:
             gap = kwargs['double']

--- a/ivy/tk_graph_ui.py
+++ b/ivy/tk_graph_ui.py
@@ -2,16 +2,16 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_ui
-import ivy_ui_util as uu
-import ivy_utils as iu
-import ivy_graph_ui
-from Tkinter import *
-import Tkconstants, tkFileDialog
-import Tix
+from . import ivy_ui
+from . import ivy_ui_util as uu
+from . import ivy_utils as iu
+from . import ivy_graph_ui
+from tkinter import *
+import tkinter.constants, tkinter.filedialog
+import tkinter.tix
 import functools
-from cy_elements import *
-from tk_cy import *
+from .cy_elements import *
+from .tk_cy import *
 
 node_styles = {
     'at_least_one' : {'width' : 4, 'double' : 5},
@@ -255,7 +255,7 @@ class TkGraphWidget(TkCyCanvas,uu.WithMenuBar):
 
     def export(self):
             tk = self.tk
-            f = tkFileDialog.asksaveasfilename(filetypes = [('dot files', '.dot')],title='Export graph as...',parent=self)
+            f = tkinter.filedialog.asksaveasfilename(filetypes = [('dot files', '.dot')],title='Export graph as...',parent=self)
             tk.eval('set myfd [open {' + f + '} w]')
             tk.eval('$graph write $myfd dot')
             tk.eval('close $myfd')
@@ -335,7 +335,7 @@ def create_relbuttons_window(gw,relbuttons):
     lb = Label(relbuttons,text="State: {}".format(gw.parent.state_label(gw.g.parent_state)))
     gw.state_label_widget = lb
     lb.pack(side = TOP)
-    sbtns = Tix.ScrolledHList(relbuttons,options='hlist.columns 5 hlist.background #ffffff',width=300)
+    sbtns = tkinter.tix.ScrolledHList(relbuttons,options='hlist.columns 5 hlist.background #ffffff',width=300)
     sbtns.pack(side="left", fill="both", expand=True)
     btns = sbtns.subwidget('hlist')
     return lb,btns

--- a/ivy/tk_ui.py
+++ b/ivy/tk_ui.py
@@ -2,16 +2,16 @@
 # Copyright (c) Microsoft Corporation. All Rights Reserved.
 #
 
-import ivy_ui
-import ivy_ui_util as uu
-import ivy_utils as iu
-import tk_graph_ui
-import tk_cy
-from cy_elements import *
-from dot_layout import dot_layout
-from Tkinter import *
-import Tkconstants, tkFileDialog
-import Tix
+from . import ivy_ui
+from . import ivy_ui_util as uu
+from . import ivy_utils as iu
+from . import tk_graph_ui
+from . import tk_cy
+from .cy_elements import *
+from .dot_layout import dot_layout
+from tkinter import *
+import tkinter.constants, tkinter.filedialog
+import tkinter.tix
 
 class RunContext(object):
     """ Context Manager that handles exceptions and reports errors. """
@@ -42,7 +42,7 @@ class TkUI(object):
 
     def __init__(self,tk=None,frame=None):
         if tk == None:
-            tk = Tix.Tk()
+            tk = tkinter.tix.Tk()
             tk.tk_setPalette(background='white')
             tk.wm_title("ivy")
             frame = tk
@@ -50,7 +50,7 @@ class TkUI(object):
             frame = Toplevel(tk)
         self.tk = tk
         self.frame = frame
-        self.notebook = Tix.NoteBook(frame)
+        self.notebook = tkinter.tix.NoteBook(frame)
         self.notebook.pack(fill=BOTH,expand=1)
         self.tab_counter = 0
         self.tabs = 0
@@ -88,7 +88,7 @@ class TkUI(object):
         if not hasattr(art,'state_graphs'):
             art.state_graphs = []
         tab = nb.add(name,label=label) 
-        pw=Tix.PanedWindow(tab,orientation='horizontal')
+        pw=tkinter.tix.PanedWindow(tab,orientation='horizontal')
         pw.pack(fill=BOTH,expand=1)
         frame=pw.add('f1',min=50)
         state_frame=pw.add('f2',min=200)
@@ -178,7 +178,7 @@ class TkUI(object):
     # filetypes is a list of pairs (extension, description).
 
     def saveas_dialog(self,msg,filetypes):
-        return tkFileDialog.asksaveasfile(mode='w',filetypes=filetypes,title=msg,parent=self.frame)
+        return tkinter.filedialog.asksaveasfile(mode='w',filetypes=filetypes,title=msg,parent=self.frame)
 
     # Return a context object to use for a computation that might take
     # take or throw an error the needs reporting

--- a/ivy/token_counter.py
+++ b/ivy/token_counter.py
@@ -1,4 +1,4 @@
-import ivy_lexer
+from . import ivy_lexer
 import sys
 
 f = open(sys.argv[1],'r')
@@ -12,5 +12,5 @@ while True:
         break      # No more input
     count += 1
 
-print count
+print(count)
 

--- a/ivy/type_inference.py
+++ b/ivy/type_inference.py
@@ -13,11 +13,11 @@ raised if the unification fails.
 
 from itertools import product, chain
 
-from logic import (Var, Const, Apply, Eq, Ite, Not, And, Or, Implies,
+from .logic import (Var, Const, Apply, Eq, Ite, Not, And, Or, Implies,
                    Iff, ForAll, Exists, NamedBinder)
-from logic import (UninterpretedSort, FunctionSort, Boolean, TopSort,
+from .logic import (UninterpretedSort, FunctionSort, Boolean, TopSort,
                    SortError, contains_topsort, is_polymorphic)
-from logic_util import used_constants, free_variables
+from .logic_util import used_constants, free_variables
 
 
 class SortVar(object):
@@ -292,28 +292,28 @@ if __name__ == '__main__':
 
     f1 = And(ps(XS), ps(xs))
     cf1 = concretize_sorts(f1)
-    print repr(f1)
-    print repr(cf1)
+    print(repr(f1))
+    print(repr(cf1))
     assert f1 == cf1
-    print
+    print()
 
     f2 = And(ps(XT), pt(xs))
     cf2 = concretize_sorts(f2)
-    print repr(f2)
-    print repr(cf2)
-    print
+    print(repr(f2))
+    print(repr(cf2))
+    print()
 
     f3 = Exists([TT], And(ps(XT), TT(xs)))
     cf3 = concretize_sorts(f3)
-    print repr(f3)
-    print repr(cf3)
-    print
+    print(repr(f3))
+    print(repr(cf3))
+    print()
 
     f4 = Iff(xt, Ite(yt, xt, XT))
     cf4 = concretize_sorts(f4)
-    print repr(f4)
-    print repr(cf4)
-    print
+    print(repr(f4))
+    print(repr(cf4))
+    print()
 
     # alpha = SortVar()
     # polyfS = FunctionSort(alpha, alpha)
@@ -326,19 +326,19 @@ if __name__ == '__main__':
 
     f6 = NamedBinder('mybinder', [XT], None, ps(XT))
     cf6 = concretize_sorts(f6)
-    print repr(f6)
-    print f6.sort
-    print repr(cf6)
-    print cf6.sort
-    print
+    print(repr(f6))
+    print(f6.sort)
+    print(repr(cf6))
+    print(cf6.sort)
+    print()
 
     f7 = NamedBinder('mybinder', [], None, ps(XT))
     cf7 = concretize_sorts(f7)
-    print repr(f7)
-    print f7.sort
-    print repr(cf7)
-    print cf7.sort
-    print
+    print(repr(f7))
+    print(f7.sort)
+    print(repr(cf7))
+    print(cf7.sort)
+    print()
 
 
     # TODO: add more tests, specifically a test that checks

--- a/ivy/ui_extensions_api.py
+++ b/ivy/ui_extensions_api.py
@@ -20,9 +20,9 @@ from IPython import get_ipython
 from IPython.display import display
 import IPython.html.widgets as widgets
 
-from widget_modal import ModalWidget
-from ivy_logic_utils import and_clauses, Clauses, close_epr
-from z3_utils import z3_implies
+from .widget_modal import ModalWidget
+from .ivy_logic_utils import and_clauses, Clauses, close_epr
+from .z3_utils import z3_implies
 
 
 

--- a/ivy/utils/immutables.py
+++ b/ivy/utils/immutables.py
@@ -177,9 +177,9 @@ def rectuple(typename, field_names, verbose=False, rename=False):
 
     # Validate the field names.  At the user's option, either generate an error
     # message or automatically replace the field name with a valid name.
-    if isinstance(field_names, basestring):
+    if isinstance(field_names, str):
         field_names = field_names.replace(',', ' ').split()
-    field_names = map(str, field_names)
+    field_names = list(map(str, field_names))
     if rename:
         seen = set()
         for index, name in enumerate(field_names):
@@ -222,14 +222,14 @@ def rectuple(typename, field_names, verbose=False, rename=False):
                                for index, name in enumerate(field_names))
     )
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for frame.f_globals['__name__']
     namespace = dict(_itemgetter=_itemgetter, __name__='rectuple_%s' % typename,
                      OrderedDict=OrderedDict, _property=property, _tuple=tuple)
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -250,8 +250,8 @@ if __name__ == '__main__':
     import pickle
     from itertools import chain, product
 
-    print "Testing tagtuple:"
-    print
+    print("Testing tagtuple:")
+    print()
 
     class A(tagtuple):
         __slots__ = ()
@@ -263,63 +263,63 @@ if __name__ == '__main__':
     b = B(1, 2, 3)
     t = (1, 2, 3)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
-    print
-    print "a[:]: ", a[:]
-    print "a[1:-1]: ", a[1:-1]
-    print "a + a: ", a + a
-    print "a + b: ", a + b
-    print "(0, ) + a: ", (0, ) + a
-    print "a + (0, ): ", a + (0, )
-    print "2 * a: ", 2 * a
-    print "a * 2: ", a * 2
-    print
-    print "A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a))
-    print "A(*product(range(3), repeat=2)): ", A(*product(range(3), repeat=2))
-    print
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))
+    print()
+    print("a[:]: ", a[:])
+    print("a[1:-1]: ", a[1:-1])
+    print("a + a: ", a + a)
+    print("a + b: ", a + b)
+    print("(0, ) + a: ", (0, ) + a)
+    print("a + (0, ): ", a + (0, ))
+    print("2 * a: ", 2 * a)
+    print("a * 2: ", a * 2)
+    print()
+    print("A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a)))
+    print("A(*product(range(3), repeat=2)): ", A(*product(list(range(3)), repeat=2)))
+    print()
 
 
-    print "Testing rectuple:"
-    print
+    print("Testing rectuple:")
+    print()
 
     A = rectuple('A', 'x y', verbose=True)
     B = rectuple('B', 'x y', verbose=True)
@@ -328,43 +328,43 @@ if __name__ == '__main__':
     b = B(1,2)
     t = (1,2)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))

--- a/ivy/utils/recstruct_object.py
+++ b/ivy/utils/recstruct_object.py
@@ -124,7 +124,7 @@ _variadic_field_template = '''\
 '''
 
 def _preprocess_names(names):
-    if isinstance(names, basestring):
+    if isinstance(names, str):
         names = names.replace(',', ' ').split()
     return [str(x) for x in names]
 
@@ -191,7 +191,7 @@ def recstruct(typename, meta_field_names, sub_field_names, verbose=False):
     )
 
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for
@@ -205,7 +205,7 @@ def recstruct(typename, meta_field_names, sub_field_names, verbose=False):
         _init=_init,
     )
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -236,93 +236,93 @@ if __name__ == '__main__':
     from itertools import chain, product
     from os.path import isfile
 
-    print "Testing recstruct:"
-    print
+    print("Testing recstruct:")
+    print()
 
     A = recstruct('A', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
     class B(recstruct('B', ('x', 'y'), ('a', 'b', '*args'), verbose=False)):
         __slots__ = ()
         @classmethod
         def _preprocess_(cls, x, y, a, b, *args):
-            return range(10)
+            return list(range(10))
 
-    a = A(*range(10))
+    a = A(*list(range(10)))
     b = B(None, None, None, None)
     t = tuple(range(10))
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print "len(a): ", len(a)
-    print "0 in a: ", 0 in a
-    print "10 in a: ", 10 in a
-    print "5 in a: ", 5 in a
-    print "a[:]: ", a[:]
-    print "a[1:]: ", a[1:]
-    print "a[1:-1]: ", a[1:-1]
-    print "a.x: ", a.x
-    print "a.y: ", a.y
-    print "a.a: ", a.a
-    print "a.b: ", a.b
-    print "a.args: ", a.args
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print("len(a): ", len(a))
+    print("0 in a: ", 0 in a)
+    print("10 in a: ", 10 in a)
+    print("5 in a: ", 5 in a)
+    print("a[:]: ", a[:])
+    print("a[1:]: ", a[1:])
+    print("a[1:-1]: ", a[1:-1])
+    print("a.x: ", a.x)
+    print("a.y: ", a.y)
+    print("a.a: ", a.a)
+    print("a.b: ", a.b)
+    print("a.args: ", a.args)
+    print()
 
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))
 
     b0 = pickle.loads(pickle.dumps(b, 0))
     b1 = pickle.loads(pickle.dumps(b, 1))
     b2 = pickle.loads(pickle.dumps(b, 2))
     b3 = pickle.loads(pickle.dumps(b))
-    print "b0: ", b0, repr(b0), b0._tup
-    print "b1: ", b1, repr(b1), b1._tup
-    print "b2: ", b2, repr(b2), b2._tup
-    print "b3: ", b3, repr(b3), b3._tup
-    print "b0 == b, hash(b0) == hash(b): ", b0 == b, hash(b0) == hash(b)
-    print "b1 == b, hash(b1) == hash(b): ", b1 == b, hash(b1) == hash(b)
-    print "b2 == b, hash(b2) == hash(b): ", b2 == b, hash(b2) == hash(b)
-    print "b3 == b, hash(b3) == hash(b): ", b3 == b, hash(b3) == hash(b)
+    print("b0: ", b0, repr(b0), b0._tup)
+    print("b1: ", b1, repr(b1), b1._tup)
+    print("b2: ", b2, repr(b2), b2._tup)
+    print("b3: ", b3, repr(b3), b3._tup)
+    print("b0 == b, hash(b0) == hash(b): ", b0 == b, hash(b0) == hash(b))
+    print("b1 == b, hash(b1) == hash(b): ", b1 == b, hash(b1) == hash(b))
+    print("b2 == b, hash(b2) == hash(b): ", b2 == b, hash(b2) == hash(b))
+    print("b3 == b, hash(b3) == hash(b): ", b3 == b, hash(b3) == hash(b))
 
     fn = 'test_pickle.txt'
     if isfile(fn):
         f = open(fn)
         bf = pickle.load(f)
         f.close()
-        print "bf: ", bf, repr(bf), bf._tup
+        print("bf: ", bf, repr(bf), bf._tup)
 
     f = open(fn, 'w')
     pickle.dump(b, f)
@@ -336,6 +336,6 @@ if __name__ == '__main__':
     e0 = pickle.loads(pickle.dumps(e, 0))
     e1 = pickle.loads(pickle.dumps(e, 1))
     e2 = pickle.loads(pickle.dumps(e, 2))
-    print "e0: ", e0, repr(e0), e0._tup
-    print "e1: ", e1, repr(e1), e1._tup
-    print "e2: ", e2, repr(e2), e2._tup
+    print("e0: ", e0, repr(e0), e0._tup)
+    print("e1: ", e1, repr(e1), e1._tup)
+    print("e2: ", e2, repr(e2), e2._tup)

--- a/ivy/utils/rectagtuple.py
+++ b/ivy/utils/rectagtuple.py
@@ -187,9 +187,9 @@ def rectuple(typename, field_names, verbose=False, rename=False):
 
     # Validate the field names.  At the user's option, either generate an error
     # message or automatically replace the field name with a valid name.
-    if isinstance(field_names, basestring):
+    if isinstance(field_names, str):
         field_names = field_names.replace(',', ' ').split()
-    field_names = map(str, field_names)
+    field_names = list(map(str, field_names))
     if rename:
         seen = set()
         for index, name in enumerate(field_names):
@@ -232,14 +232,14 @@ def rectuple(typename, field_names, verbose=False, rename=False):
                                for index, name in enumerate(field_names))
     )
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for frame.f_globals['__name__']
     namespace = dict(_itemgetter=_itemgetter, __name__='rectuple_%s' % typename,
                      OrderedDict=OrderedDict, _property=property, _tuple=tuple)
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -260,8 +260,8 @@ if __name__ == '__main__':
     import pickle
     from itertools import chain, product
 
-    print "Testing tagtuple:"
-    print
+    print("Testing tagtuple:")
+    print()
 
     class A(tagtuple):
         __slots__ = ()
@@ -273,63 +273,63 @@ if __name__ == '__main__':
     b = B(1, 2, 3)
     t = (1, 2, 3)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
-    print
-    print "a[:]: ", a[:]
-    print "a[1:-1]: ", a[1:-1]
-    print "a + a: ", a + a
-    print "a + b: ", a + b
-    print "(0, ) + a: ", (0, ) + a
-    print "a + (0, ): ", a + (0, )
-    print "2 * a: ", 2 * a
-    print "a * 2: ", a * 2
-    print
-    print "A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a))
-    print "A(*product(range(3), repeat=2)): ", A(*product(range(3), repeat=2))
-    print
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))
+    print()
+    print("a[:]: ", a[:])
+    print("a[1:-1]: ", a[1:-1])
+    print("a + a: ", a + a)
+    print("a + b: ", a + b)
+    print("(0, ) + a: ", (0, ) + a)
+    print("a + (0, ): ", a + (0, ))
+    print("2 * a: ", 2 * a)
+    print("a * 2: ", a * 2)
+    print()
+    print("A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a)))
+    print("A(*product(range(3), repeat=2)): ", A(*product(list(range(3)), repeat=2)))
+    print()
 
 
-    print "Testing rectuple:"
-    print
+    print("Testing rectuple:")
+    print()
 
     A = rectuple('A', 'x y', verbose=True)
     B = rectuple('B', 'x y', verbose=True)
@@ -338,43 +338,43 @@ if __name__ == '__main__':
     b = B(1,2)
     t = (1,2)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))

--- a/ivy/utils/try1.py
+++ b/ivy/utils/try1.py
@@ -252,7 +252,7 @@ def rectagtuple(typename,
     )
 
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for
@@ -260,7 +260,7 @@ def rectagtuple(typename,
     namespace = dict(__name__='rectagtuple_{}'.format(typename),
                      _tupler=lambda *x: x)
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -296,8 +296,8 @@ if __name__ == '__main__':
     import pickle
     from itertools import chain, product
 
-    print "Testing tagtuple:"
-    print
+    print("Testing tagtuple:")
+    print()
 
     class A(tagtuple):
         __slots__ = ()
@@ -309,51 +309,51 @@ if __name__ == '__main__':
     b = B(1, 2, 3)
     t = (1, 2, 3)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
 
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
-    print
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))
+    print()
 
-    print "a[:]: ", a[:]
-    print "a[1:-1]: ", a[1:-1]
+    print("a[:]: ", a[:])
+    print("a[1:-1]: ", a[1:-1])
     """
     print "a + a: ", a + a
     print "a + b: ", a + b
@@ -363,13 +363,13 @@ if __name__ == '__main__':
     print "a * 2: ", a * 2
     print
     """
-    print "A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a))
-    print "A(*product(range(3), repeat=2)): ", A(*product(range(3), repeat=2))
-    print
+    print("A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a)))
+    print("A(*product(range(3), repeat=2)): ", A(*product(list(range(3)), repeat=2)))
+    print()
 
 
-    print "Testing rectuple:"
-    print
+    print("Testing rectuple:")
+    print()
 
     A = rectuple('A', ('x', 'y'), verbose=True)
     B = rectuple('B', ('x', 'y'), verbose=True)
@@ -378,43 +378,43 @@ if __name__ == '__main__':
     b = B(1,2)
     t = (1,2)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
     a2 = pickle.loads(pickle.dumps(a, 2))
-    print "a0: ", a0
-    print "a1: ", a1
-    print "a2: ", a2
-    print "a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a)
-    print "a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a)
-    print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
+    print("a0: ", a0)
+    print("a1: ", a1)
+    print("a2: ", a2)
+    print("a0 == a, hash(a0) == hash(a): ", a0 == a, hash(a0) == hash(a))
+    print("a1 == a, hash(a1) == hash(a): ", a1 == a, hash(a1) == hash(a))
+    print("a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a))

--- a/ivy/utils/try11.py
+++ b/ivy/utils/try11.py
@@ -247,7 +247,7 @@ def rectagtuple(typename,
     )
 
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for
@@ -260,7 +260,7 @@ def rectagtuple(typename,
                      _init=_init,
                  )
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -296,8 +296,8 @@ if __name__ == '__main__':
     import pickle
     from itertools import chain, product
 
-    print "Testing tagtuple:"
-    print
+    print("Testing tagtuple:")
+    print()
 
     class A(tagtuple):
         __slots__ = ()
@@ -309,37 +309,37 @@ if __name__ == '__main__':
     b = B(1, 2, 3)
     t = (1, 2, 3)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
@@ -352,8 +352,8 @@ if __name__ == '__main__':
     print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
     print
     """
-    print "a[:]: ", a[:]
-    print "a[1:-1]: ", a[1:-1]
+    print("a[:]: ", a[:])
+    print("a[1:-1]: ", a[1:-1])
     """
     print "a + a: ", a + a
     print "a + b: ", a + b
@@ -363,13 +363,13 @@ if __name__ == '__main__':
     print "a * 2: ", a * 2
     print
     """
-    print "A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a))
-    print "A(*product(range(3), repeat=2)): ", A(*product(range(3), repeat=2))
-    print
+    print("A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a)))
+    print("A(*product(range(3), repeat=2)): ", A(*product(list(range(3)), repeat=2)))
+    print()
 
 
-    print "Testing rectuple:"
-    print
+    print("Testing rectuple:")
+    print()
 
     A = rectuple('A', ('x', 'y'), verbose=True)
     B = rectuple('B', ('x', 'y'), verbose=True)
@@ -378,37 +378,37 @@ if __name__ == '__main__':
     b = B(1,2)
     t = (1,2)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
@@ -421,58 +421,58 @@ if __name__ == '__main__':
     print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
     """
 
-    print "Testing rectagtuple:"
-    print
+    print("Testing rectagtuple:")
+    print()
 
     A = rectagtuple('A', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
     B = rectagtuple('B', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
 
-    a = A(*range(10))
-    b = B(*range(10))
+    a = A(*list(range(10)))
+    b = B(*list(range(10)))
     t = tuple(range(10))
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print "0 in a: ", 0 in a
-    print "10 in a: ", 10 in a
-    print "5 in a: ", 5 in a
-    print "a[:]: ", a[:]
-    print "a[1:]: ", a[1:]
-    print "a[1:-1]: ", a[1:-1]
-    print "a.x: ", a.x
-    print "a.y: ", a.y
-    print "a.a: ", a.a
-    print "a.b: ", a.b
-    print "a.args: ", a.args
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print("0 in a: ", 0 in a)
+    print("10 in a: ", 10 in a)
+    print("5 in a: ", 5 in a)
+    print("a[:]: ", a[:])
+    print("a[1:]: ", a[1:])
+    print("a[1:-1]: ", a[1:-1])
+    print("a.x: ", a.x)
+    print("a.y: ", a.y)
+    print("a.a: ", a.a)
+    print("a.b: ", a.b)
+    print("a.args: ", a.args)
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))

--- a/ivy/utils/try2.py
+++ b/ivy/utils/try2.py
@@ -100,7 +100,7 @@ def rectagtuple(typename,
     )
 
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for
@@ -113,7 +113,7 @@ def rectagtuple(typename,
                      _islice=islice,
                  )
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -150,8 +150,8 @@ if __name__ == '__main__':
     import pickle
     from itertools import chain, product
 
-    print "Testing tagtuple:"
-    print
+    print("Testing tagtuple:")
+    print()
 
     class A(tagtuple):
         __slots__ = ()
@@ -163,37 +163,37 @@ if __name__ == '__main__':
     b = B(1, 2, 3)
     t = (1, 2, 3)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
@@ -206,8 +206,8 @@ if __name__ == '__main__':
     print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
     print
     """
-    print "a[:]: ", a[:]
-    print "a[1:-1]: ", a[1:-1]
+    print("a[:]: ", a[:])
+    print("a[1:-1]: ", a[1:-1])
     """
     print "a + a: ", a + a
     print "a + b: ", a + b
@@ -217,13 +217,13 @@ if __name__ == '__main__':
     print "a * 2: ", a * 2
     print
     """
-    print "A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a))
-    print "A(*product(range(3), repeat=2)): ", A(*product(range(3), repeat=2))
-    print
+    print("A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a)))
+    print("A(*product(range(3), repeat=2)): ", A(*product(list(range(3)), repeat=2)))
+    print()
 
 
-    print "Testing rectuple:"
-    print
+    print("Testing rectuple:")
+    print()
 
     A = rectuple('A', ('x', 'y'), verbose=True)
     B = rectuple('B', ('x', 'y'), verbose=True)
@@ -232,37 +232,37 @@ if __name__ == '__main__':
     b = B(1,2)
     t = (1,2)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
@@ -275,53 +275,53 @@ if __name__ == '__main__':
     print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
     """
 
-    print "Testing rectagtuple:"
-    print
+    print("Testing rectagtuple:")
+    print()
 
     A = rectagtuple('A', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
     B = rectagtuple('B', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
 
-    a = A(*range(10))
-    b = B(*range(10))
+    a = A(*list(range(10)))
+    b = B(*list(range(10)))
     t = tuple(range(10))
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print "0 in a: ", 0 in a
-    print "10 in a: ", 10 in a
-    print "5 in a: ", 5 in a
-    print "a[:]: ", a[:]
-    print "a[1:]: ", a[1:]
-    print "a[1:-1]: ", a[1:-1]
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print("0 in a: ", 0 in a)
+    print("10 in a: ", 10 in a)
+    print("5 in a: ", 5 in a)
+    print("a[:]: ", a[:])
+    print("a[1:]: ", a[1:])
+    print("a[1:-1]: ", a[1:-1])
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))

--- a/ivy/utils/try3.py
+++ b/ivy/utils/try3.py
@@ -120,7 +120,7 @@ def rectagtuple(typename,
     )
 
     if verbose:
-        print class_definition
+        print(class_definition)
 
     # Execute the template string in a temporary namespace and support
     # tracing utilities by setting a value for
@@ -134,7 +134,7 @@ def rectagtuple(typename,
                      _islice=islice,
                  )
     try:
-        exec class_definition in namespace
+        exec(class_definition, namespace)
     except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_definition)
     result = namespace[typename]
@@ -171,8 +171,8 @@ if __name__ == '__main__':
     import pickle
     from itertools import chain, product
 
-    print "Testing tagtuple:"
-    print
+    print("Testing tagtuple:")
+    print()
 
     class A(tagtuple):
         __slots__ = ()
@@ -184,37 +184,37 @@ if __name__ == '__main__':
     b = B(1, 2, 3)
     t = (1, 2, 3)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
@@ -227,8 +227,8 @@ if __name__ == '__main__':
     print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
     print
     """
-    print "a[:]: ", a[:]
-    print "a[1:-1]: ", a[1:-1]
+    print("a[:]: ", a[:])
+    print("a[1:-1]: ", a[1:-1])
     """
     print "a + a: ", a + a
     print "a + b: ", a + b
@@ -238,13 +238,13 @@ if __name__ == '__main__':
     print "a * 2: ", a * 2
     print
     """
-    print "A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a))
-    print "A(*product(range(3), repeat=2)): ", A(*product(range(3), repeat=2))
-    print
+    print("A(*chain((x**2 for x in range(10)), a)): ", A(*chain((x**2 for x in range(10)), a)))
+    print("A(*product(range(3), repeat=2)): ", A(*product(list(range(3)), repeat=2)))
+    print()
 
 
-    print "Testing rectuple:"
-    print
+    print("Testing rectuple:")
+    print()
 
     A = rectuple('A', ('x', 'y'), verbose=True)
     B = rectuple('B', ('x', 'y'), verbose=True)
@@ -253,37 +253,37 @@ if __name__ == '__main__':
     b = B(1,2)
     t = (1,2)
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))
@@ -296,58 +296,58 @@ if __name__ == '__main__':
     print "a2 == a, hash(a2) == hash(a): ", a2 == a, hash(a2) == hash(a)
     """
 
-    print "Testing rectagtuple:"
-    print
+    print("Testing rectagtuple:")
+    print()
 
     A = rectagtuple('A', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
     B = rectagtuple('B', ('x', 'y'), ('a', 'b', '*args'), verbose=True)
 
-    a = A(*range(10))
-    b = B(*range(10))
+    a = A(*list(range(10)))
+    b = B(*list(range(10)))
     t = tuple(range(10))
 
-    print "a: ", a
-    print "b: ", b
-    print "t: ", t
-    print
-    print "a == b: ", a == b
-    print "a != b: ", a != b
-    print "hash(a) == hash(b): ", hash(a) == hash(b)
-    print "a <= b: ", a <= b
-    print "b <= a: ", b <= a
-    print
-    print "a == t: ", a == t
-    print "a != t: ", a != t
-    print "hash(a) == hash(t): ", hash(a) == hash(t)
-    print "a <= t: ", a <= t
-    print "t <= a: ", t <= a
-    print
+    print("a: ", a)
+    print("b: ", b)
+    print("t: ", t)
+    print()
+    print("a == b: ", a == b)
+    print("a != b: ", a != b)
+    print("hash(a) == hash(b): ", hash(a) == hash(b))
+    print("a <= b: ", a <= b)
+    print("b <= a: ", b <= a)
+    print()
+    print("a == t: ", a == t)
+    print("a != t: ", a != t)
+    print("hash(a) == hash(t): ", hash(a) == hash(t))
+    print("a <= t: ", a <= t)
+    print("t <= a: ", t <= a)
+    print()
     d = {}
     d[a] = 1
     d[b] = 2
     d[t] = 3
-    print "d: ", d
+    print("d: ", d)
     s = set()
     s.add(a)
     s.add(b)
     s.add(t)
-    print "s: ", s
-    print
-    print "tuple(x for x in a): ", tuple(x for x in a)
-    print "list(a): ", list(a)
-    print "tuple(a): ", tuple(a)
-    print "0 in a: ", 0 in a
-    print "10 in a: ", 10 in a
-    print "5 in a: ", 5 in a
-    print "a[:]: ", a[:]
-    print "a[1:]: ", a[1:]
-    print "a[1:-1]: ", a[1:-1]
-    print "a.x: ", a.x
-    print "a.y: ", a.y
-    print "a.a: ", a.a
-    print "a.b: ", a.b
-    print "a.args: ", a.args
-    print
+    print("s: ", s)
+    print()
+    print("tuple(x for x in a): ", tuple(x for x in a))
+    print("list(a): ", list(a))
+    print("tuple(a): ", tuple(a))
+    print("0 in a: ", 0 in a)
+    print("10 in a: ", 10 in a)
+    print("5 in a: ", 5 in a)
+    print("a[:]: ", a[:])
+    print("a[1:]: ", a[1:])
+    print("a[1:-1]: ", a[1:-1])
+    print("a.x: ", a.x)
+    print("a.y: ", a.y)
+    print("a.a: ", a.a)
+    print("a.b: ", a.b)
+    print("a.args: ", a.args)
+    print()
     """
     a0 = pickle.loads(pickle.dumps(a, 0))
     a1 = pickle.loads(pickle.dumps(a, 1))

--- a/ivy/widget_cy_graph.py
+++ b/ivy/widget_cy_graph.py
@@ -12,7 +12,7 @@ from IPython.html import widgets
 from IPython.utils.traitlets import Unicode, Any, Bool, Tuple
 from IPython.utils.py3compat import string_types
 
-from cy_elements import CyElements
+from .cy_elements import CyElements
 
 def _object_key(x):
     return str(id(x))
@@ -164,7 +164,7 @@ class CyElements(object):
         assert self.elements is not None, "This object us not reusable"
         if label is None:
             label = str(obj)
-        if not isinstance(classes, basestring):
+        if not isinstance(classes, str):
             classes = ' '.join(str(x) for x in classes)
         nid = 'n{}'.format(len(self.node_id))
         assert obj not in self.node_id, "obj must be unique"
@@ -198,7 +198,7 @@ class CyElements(object):
         assert self.elements is not None, "This object us not reusable"
         if label is None:
             label = str(obj)
-        if not isinstance(classes, basestring):
+        if not isinstance(classes, str):
             classes = ' '.join(str(x) for x in classes)
         eid = 'e{}'.format(len(self.edge_id))
         assert (obj, source_obj, target_obj) not in self.edge_id

--- a/ivy/z3_utils.py
+++ b/ivy/z3_utils.py
@@ -9,9 +9,9 @@ Ideally, this file should be the only file to improt the z3 module
 
 import z3
 
-from logic import (Var, Const, Apply, Eq, Ite, Not, And, Or, Implies,
+from .logic import (Var, Const, Apply, Eq, Ite, Not, And, Or, Implies,
                    Iff, ForAll, Exists)
-from logic import (UninterpretedSort, FunctionSort, Boolean, true,
+from .logic import (UninterpretedSort, FunctionSort, Boolean, true,
                    false, first_order_sort)
 
 
@@ -127,7 +127,7 @@ def z3_implies(f1, f2, timeout=False):
         return True
     else:
         # no caching of unknown results
-        print "z3 returned: {}".format(res)
+        print("z3 returned: {}".format(res))
         assert False
         return None
 
@@ -164,7 +164,7 @@ def z3_implies_batch(premise, formulas, timeout=False):
                 result.append(True)
             else:
                 # no caching of unknown results
-                print "z3 returned: {}".format(res)
+                print("z3 returned: {}".format(res))
                 assert False
                 result.append(None)
     return result
@@ -180,17 +180,17 @@ if __name__ == '__main__':
     transitive3 = Not(Exists((X, Y, Z), And(leq(X,Y), leq(Y,Z), Not(leq(X,Z)))))
     antisymmetric = ForAll((X, Y), Implies(And(leq(X,Y), leq(Y,X), true), Eq(Y,X)))
 
-    print z3_implies(transitive1, transitive2)
-    print z3_implies(transitive2, transitive3)
-    print z3_implies(transitive3, transitive1)
-    print z3_implies(transitive3, antisymmetric)
-    print
+    print(z3_implies(transitive1, transitive2))
+    print(z3_implies(transitive2, transitive3))
+    print(z3_implies(transitive3, transitive1))
+    print(z3_implies(transitive3, antisymmetric))
+    print()
 
-    print z3_implies(true, Iff(transitive1, transitive2))
-    print
+    print(z3_implies(true, Iff(transitive1, transitive2)))
+    print()
 
     x, y = (Const(n, S) for n in ['x', 'y'])
     b = Const('b', Boolean)
-    print z3_implies(b, Eq(Ite(b, x, y), x))
-    print z3_implies(Not(b), Eq(Ite(b, x, y), y))
-    print z3_implies(Not(Eq(x,y)), Iff(Eq(Ite(b, x, y), x), b))
+    print(z3_implies(b, Eq(Ite(b, x, y), x)))
+    print(z3_implies(Not(b), Eq(Ite(b, x, y), y)))
+    print(z3_implies(Not(Eq(x,y)), Iff(Eq(Ite(b, x, y), x), b)))

--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,16 @@ setup(name='ms_ivy',
       author_email='nomail@example.com',
       license='MIT',
       packages=find_packages(),
-      package_data=({'ivy':['include/*/*.ivy','include/*/*.h','include/*.h','lib/*.dll','lib/*.lib','z3/*.dll']}
+      package_data=({'ivy':['include/*/*.ivy','include/*/*.h','include/*.h','lib/*.dll','lib/*.lib']}
                     if platform.system() == 'Windows' else
-                    {'ivy':['include/*/*.ivy','include/*/*.h','include/*.h','lib/*.dylib','lib/*.a','z3/*.dylib']}
+                    {'ivy':['include/*/*.ivy','include/*/*.h','include/*.h','lib/*.dylib','lib/*.a']}
                     if platform.system() == 'Darwin' else
-                    {'ivy':['include/*/*.ivy','include/*/*.h','include/*.h','lib/*.so','lib/*.a','z3/*.so','ivy2/s3/ivyc_s3']}),
+                    {'ivy':['include/*/*.ivy','include/*/*.h','include/*.h','lib/*.so','lib/*.a','ivy2/s3/ivyc_s3']}),
       install_requires=[
           'ply',
           'tarjan',
           'pydot',
+          'z3-solver'
       ],
       entry_points = {
         'console_scripts': ['ivy=ivy.ivy:main','ivy_check=ivy.ivy_check:main','ivy_to_cpp=ivy.ivy_to_cpp:main','ivy_show=ivy.ivy_show:main','ivy_ev_viewer=ivy.ivy_ev_viewer:main','ivyc=ivy.ivy_to_cpp:ivyc','ivy_to_md=ivy.ivy_to_md:main','ivy_libs=ivy.ivy_libs:main'],

--- a/test/afterinit2.py
+++ b/test/afterinit2.py
@@ -30,5 +30,5 @@ with im.Module():
         ick.check_module()
         assert False,"safety should have failed"
     except iu.IvyError as e:
-        print e
+        print(e)
         assert str(e) == "error: failed checks: 1"

--- a/test/check1.py
+++ b/test/check1.py
@@ -40,7 +40,7 @@ with im.Module():
         ick.check_module()
         assert False,"property should have been false"
     except iu.IvyError as e:
-        print str(e)
+        print(str(e))
         assert str(e) == 'error: failed checks: 1'
 
 

--- a/test/client_server5.py
+++ b/test/client_server5.py
@@ -57,7 +57,7 @@ with ivy_module.Module():
     cg.strengthen()
     main_ui.answer("OK")
     if not ui.check_inductiveness():
-        print "result of inductiveness check should have been true"
+        print("result of inductiveness check should have been true")
         exit(1)
 
 

--- a/test/native.py
+++ b/test/native.py
@@ -46,8 +46,8 @@ with im.Module():
     classname = 'foo'
     with ivy_cpp.CppContext():
         header,impl = i2c.module_to_cpp_class(classname,classname)
-    print header
-    print impl
+    print(header)
+    print(impl)
 
 #     main_ui.answer("OK")
 #     ui.check_inductiveness()

--- a/test/nesteddestr1.py
+++ b/test/nesteddestr1.py
@@ -29,5 +29,5 @@ export a
 with im.Module():
     iu.set_parameters({'show_compiled':'true'})
     ivy_from_string(prog,create_isolate=False)
-    print im.module.actions["a"].update(im.module,{})
+    print(im.module.actions["a"].update(im.module,{}))
 

--- a/test/pretty.py
+++ b/test/pretty.py
@@ -28,10 +28,10 @@ with im.Module():
     ivy_from_string(prog,create_isolate=False)
     for adecl in im.module.labeled_axioms:
         f = adecl.args[1]
-        print
-        print str(f)
-        print il.to_str_with_var_sorts(f)
-        print il.fmla_to_str_ambiguous(f)
+        print()
+        print(str(f))
+        print(il.to_str_with_var_sorts(f))
+        print(il.fmla_to_str_ambiguous(f))
 
 #     main_ui.answer("OK")
 #     ui.check_inductiveness()

--- a/test/property1.py
+++ b/test/property1.py
@@ -32,7 +32,7 @@ with im.Module():
         ick.check_module()
         assert False,"property should have been false"
     except iu.IvyError as e:
-        print str(e)
+        print(str(e))
         assert str(e) == 'error: failed checks: 1'
 
     

--- a/test/run_expects.py
+++ b/test/run_expects.py
@@ -165,33 +165,33 @@ class Test(object):
     def run(self):
         oldcwd = os.getcwd()
         os.chdir(self.dir)
-        print '{}/{} ...'.format(self.dir,self.name)
+        print('{}/{} ...'.format(self.dir,self.name))
         status = self.run_expect()
-        print 'PASS' if status else 'FAIL'
+        print('PASS' if status else 'FAIL')
         os.chdir(oldcwd)
         return status
     def run_expect(self):
         for pc in self.preprocess_commands():
-            print 'executing: {}'.format(pc)
+            print('executing: {}'.format(pc))
             child = spawn(pc)
             child.logfile = sys.stdout
             child.expect(pexpect.EOF)
             child.close()
             if child.exitstatus != 0:
 #            if child.wait() != 0:
-                print child.before
+                print(child.before)
                 return False
         return self.expect()
     def expect(self):
         command = self.command()
-        print command
+        print(command)
         child = spawn(command)
 #        child.logfile = sys.stdout
         try:
             child.expect(self.res)
             return True
         except pexpect.EOF:
-            print child.before
+            print(child.before)
             return False
     def preprocess_commands(self):
         return []
@@ -219,7 +219,7 @@ class IvyRepl(Test):
         make_directory_exist('build')
         return ['ivy_to_cpp target=repl build=true '+' '.join(self.opts) + ' '+self.name+'.ivy']
     def expect(self):
-        print 'wd:{}'.format(os.getcwd())
+        print('wd:{}'.format(os.getcwd()))
         modname = self.res if self.res != None else (self.name+'_expect')
         mod = imp.load_source(modname,modname+'.py')
         return mod.run('build/'+self.name,self.opts,self.res)
@@ -227,7 +227,7 @@ class IvyRepl(Test):
 class IvyToCpp(Test):
     def command(self):
         res = 'ivy_to_cpp ' + ' '.join(self.opts) + ' '+self.name+'.ivy'
-        print 'compiling: {}'.format(res)
+        print('compiling: {}'.format(res))
         return res
 
 def make_directory_exist(dir):
@@ -256,13 +256,13 @@ for arg in sys.argv[1:]:
         usage()
 
 def usage():
-    print """usage:
+    print("""usage:
     {} [option...]
 options:
     type=<test type pattern>
     dir=<test directory pattern>
     name=<test name pattern>
-""".format(sys.argv[0])
+""".format(sys.argv[0]))
     sys.exit(1)
 
 def get_tests(cls,arr):
@@ -288,9 +288,9 @@ for test in all_tests:
     if not status:
         num_failures += 1
 if num_failures:
-    print 'error: {} tests(s) failed'.format(num_failures)
+    print('error: {} tests(s) failed'.format(num_failures))
 else:
-    print 'OK'
+    print('OK')
 
 # for checkd in checks:
 #     dir,checkl = checkd

--- a/test/strlit1.py
+++ b/test/strlit1.py
@@ -25,7 +25,7 @@ with im.Module():
     try:
         ick.check_module()
     except iu.IvyError as e:
-        print str(e)
+        print(str(e))
         assert False,"property should have been true"
 
     


### PR DESCRIPTION
This is "about as minimal" a change from python 2 -> 3 as I can manage. It produces the same results on `test/runall` when run in a python 3 venv as the pre-change version in a python 2 venv. At least the python tests -- the shell tests don't work for me in either case. I will look into them further.

It includes a possibly-controversial change to stop using the bundled z3 and switch to the stock z3-prover package in PyPI, moving to 4.8.10 -- this seems to be the simplest route to avoid forking the submodule version of z3 with python3 changes.

I'm sure I missed stuff, and will continue to submit fixes in followup PRs as I find them.. The python 2 -> 3 migration story seems like it's just inherently bumpy. Dynamic-typed language, no static checks, and a bunch of semantics and stdlib functions just randomly changed. But it seems these changes are enough to get off the ground.

(There's also a slightly silly fix in 4b013cc related to an upstream Z3 bug which I already filed a fix for -- https://github.com/Z3Prover/z3/pull/5079 -- but I'm not sure how long it'll take for that to show up in a subsequent PyPI-packaged Z3 release. We'll see!)