### PR TITLE
ivy_to_cpp.py::emit_quant() Call instanceof() with the correct number of params

### DIFF
--- a/ivy/ivy_to_cpp.py
+++ b/ivy/ivy_to_cpp.py
@@ -3853,7 +3853,7 @@ def emit_quant(variables,body,header,code,exists=False):
             ebnds = []
             get_extensional_bound_exprs(v0,body,exists,ebnds)
             if not ebnds:
-                if not isinstance(berr):
+                if not isinstance(berr,BoundsError):
                     berr = BoundsError(None,"cannot iterate over sort {}".format(v0.sort))
                 berr.throw()
             ebnd = ebnds[0]


### PR DESCRIPTION
Whilst trying to compile the following (incorrect) assertion:

```
 96         ensure forall P1:pid,P2:pid,I. msg_count = 0 ->
 97             host(P1).contents.end = host(P2).contents.end &
 98             (I < host(P1).contents.end -> host(P1).contents.value(I) = host(P2).contents.value(I));
```

`ivyc` raises an exception:

```
 $ ivyc target=test homework2.ivy
...
  File "/Users/ntaylor/school/phd/coursework/395T_mcmillan/ivy-venv/lib/python2.7/site-packages/ivy/ivy_to_cpp.py", line 3856, in emit_quant
    if not isinstance(berr):
TypeError: isinstance expected 2 arguments, got 1
```

That line was just missing the class to compare berr against. From context I believe this should be checking for BoundsError, in a similar way to what's done a few lines up.

With the patch applied, the compiler now reports: `homework2.ivy: line 96: error: cannot find an upper bound for I:file.domain`.