### PR TITLE
Start from `seed` when `seed=...` and `runs=...` are passed to cmd line

### DIFF
--- a/ivy/ivy_launch.py
+++ b/ivy/ivy_launch.py
@@ -172,12 +172,16 @@ def main():
                             cmd.append('{}={}'.format(param['name'],val))
                         else:
                             cmd.append('{}'.format(val))
+                start_seed = 0  # default start seed
                 if 'test_params' in descriptor:
                     for param in descriptor['test_params']:
                         if param in ps:
-                            cmd.append('{}={}'.format(param,ps[param]))
+                            if param == 'seed' and have_runs:
+                                start_seed = int(ps[param])
+                            else:
+                                cmd.append('{}={}'.format(param,ps[param]))
                 if have_runs:
-                    cmd.append("seed={}".format(run))
+                    cmd.append("seed={}".format(start_seed + run))
                 print ' '.join(cmd)
                 pname = process['name']
                 if pname == 'this':


### PR DESCRIPTION
If a user calls `ivy_launch` with both `seed` and `runs`, the current implementation produces something like this:
```
> ivy_launch runs=3 seed=10 my_program
`ivy_shell`; ./my_program ...  seed=10 seed=0
`ivy_shell`; ./my_program ...  seed=10 seed=0
`ivy_shell`; ./my_program ...  seed=10 seed=0
```

This PR changes the behavior so that the `seed` argument acts as the initial-value for `runs`, i.e. `ivy_launch` will produce
```
> ivy_launch runs=3 seed=10 my_program
`ivy_shell`; ./my_program ...  seed=10
`ivy_shell`; ./my_program ...  seed=11
`ivy_shell`; ./my_program ...  seed=12
```