### PR TITLE
Vim Syntax highlighting

### DIFF
--- a/lib/vim/install_vim.sh
+++ b/lib/vim/install_vim.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -R ~/.vim/syntax
+cp ivy.vim ~/.vim/syntax
+
+mkdir -R ~/.vim/ftdetect
+echo "au BufRead,BufNewFile *.ivy set filetype=ivy" >> ~/.vim/ftdetect

--- a/lib/vim/ivy.vim
+++ b/lib/vim/ivy.vim
@@ -1,0 +1,65 @@
+" Vim syntax file
+" Language: Ivy Model Checker
+" Maintainer: Josh Jeppson
+" Latest Revision: 9 November 2021
+
+if exists("b:current_syntax")
+	finish
+endif
+
+" Keywords
+
+syn keyword ivyLang import with include export mixin using attribute
+
+syn keyword ivyControlFlow if else for forall while decreases
+syn keyword ivyControlFlow of instantiate derived
+syn keyword ivyControlFlow link call after init execute
+syn keyword ivyControlFlow before after around returns
+syn keyword ivyControlFlow update params ensures requires modifies
+syn keyword ivyControlFlow rely mixord extract some maximizing
+syn keyword ivyControlFlow apply global named
+
+syn keyword ivyObjects this instance fresh local entry macro progress autoinstance
+syn keyword ivyObjects temporal tactic subclass field template process
+
+syn keyword ivyBlocks module function individual action relation object specification
+syn keyword ivyBlocks class object method destructor private public ghost implement implementation
+
+syn keyword ivyCheck property parameter alias trusted proof require
+syn keyword ivyChecks invariant variant ensure assume relation axiom 
+syn keyword ivyChecks monitor exists axiom definition isolate delegate
+syn keyword ivyChecks conjecture schema concept assert from theorem
+
+syn keyword ivyTypes type nat bool int interpret state set null bv
+
+syn keyword ivyConstants true false
+
+" Integers (with +/- at the front)
+syn match ivyNumber '[\n \t]\d\+'
+syn match ivyNumber '[+-]\d\+'
+
+" Floating points (including scientific notation)
+syn match ivyNumber '[+-]\d\+\.\d*'
+" TODO: Add support for scientific notation
+
+" Strings
+syn region ivyString start='"' end='"'
+
+" Comments
+syn match ivyComment "#.*$"
+
+" Blocks
+syn region ivyBlock start="{" end="}" fold transparent
+
+" Putting it together:
+let b:current_syntax = "ivy"
+
+hi def link ivyComment 		Comment
+hi def link ivyControlFlow	Statement
+hi def link ivyBlocks 		Statement
+hi def link ivyChecks		Statement
+hi def link ivyObjects 		Type
+hi def link ivyTypes 		Type
+hi def link ivyNumber 		Constant
+hi def link ivyString 		Constant
+hi def link ivyLang			PreProc


### PR DESCRIPTION
Hey,

I'm a student at Utah State University, and we use Ivy for both research and a verification class I'm taking. I'm a vim user, and I noticed you only have syntax highlighting for emacs, so I decided to create a syntax file for vim. Perhaps others can use it as well.