### PR TITLE
Allow casting of range types inside ivy_check

### DIFF
--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -274,6 +274,8 @@ def lookup_native(thing,table,kind):
                         return lambda x,y: z3.If(x*y > ub, ub, z3.If(x*y < lb, lb, x*y))
                     if thing.name == '/':
                         return lambda x,y: z3.If(x/y > ub, ub, z3.If(x/y < lb, lb, x/y))
+                    if thing.name == 'cast':
+                        return lambda x:x
                 z3val = table(thing.name)
                 if z3val == None:
                     raise iu.IvyError(None,'{} is not a supported Z3 {}'.format(name,kind))


### PR DESCRIPTION
This commit seeks to enable casting of range types to integer types inside isolates.

Running `ivyc` on this example works. However, running `ivy_check` produces the error `cast is not a supported Z3 function`.
```
#lang ivy1.8

include collections
include numbers

isolate adder = {
    var value : nat
    type one_t = {1}
    export action add = {
        var one : one_t := 1;
        require value >= cast(one);
    }
}
```