### PR TITLE
Cache invariants & color PASS/FAIL/[assumed]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ specs
 
 # These are library directories
 gnutls
+ivy/include/*.h
+include/
+ivy/bin/
+ivy/lib/
+ivy/z3/
+*.so
+bin/z3

--- a/ivy/ivy_check.py
+++ b/ivy/ivy_check.py
@@ -169,7 +169,17 @@ failures = 0
 def print_dots():
     print '...',
     sys.stdout.flush()
-    
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m' 
 
 class Checker(object):
     def __init__(self,conj,report_pass=True,invert=True):
@@ -186,14 +196,14 @@ class Checker(object):
         if self.report_pass:
             print_dots()
     def sat(self):
-        print('FAIL')
+        print(bcolors.FAIL + 'FAIL' + bcolors.ENDC)
         global failures
         failures += 1
         self.failed = True
         return not (diagnose.get() or opt_trace.get()) # ignore failures if not diagnosing
     def unsat(self):
         if self.report_pass:
-            print('PASS')
+            print(bcolors.OKGREEN + 'PASS' + bcolors.ENDC)
     def assume(self):
         return False
     def get_annot(self):
@@ -224,7 +234,7 @@ class ConjAssumer(Checker):
         self.lf = lf
         Checker.__init__(self,lf.formula,invert=False)
     def start(self):
-        print pretty_lf(self.lf) + "  [assumed]"
+        print pretty_lf(self.lf) + bcolors.OKBLUE + "  [assumed]" + bcolors.ENDC
     def assume(self):
         return True
 
@@ -589,7 +599,7 @@ def check_isolate():
                                    some_failed = True
                                    break
                         if not some_failed:
-                            print 'PASS'
+                            print bcolors.OKGREEN + 'PASS' + bcolors.ENDC
                         act.checked_assert.value = old_checked_assert
                     else:
                         print ""
@@ -714,7 +724,7 @@ def mc_isolate(isolate,meth=ivy_mc.check_isolate):
             res = meth()
             if res is not None:
                 print res
-                print 'FAIL'
+                print bcolors.FAIL + 'FAIL' + bcolors.ENDC
                 exit(1)
         return
     for lineno in all_assert_linenos():
@@ -725,7 +735,7 @@ def mc_isolate(isolate,meth=ivy_mc.check_isolate):
                 res = meth()
             if res is not None:
                 print res
-                print 'FAIL'
+                print bcolors.FAIL + 'FAIL' + bcolors.ENDC
                 exit(1)
             act.checked_assert.value = old_checked_assert
     

--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -1090,20 +1090,46 @@ def model_if_none(clauses1,implied,model):
             s.pop()
     return h
 
+def databaseContains(database, tag):
+    if database == None or tag == None:
+        return False
+    try:
+        with open(database, 'r') as fr:
+            for line in fr:
+                if line.strip() == tag:
+                    return True
+    except Exception as e:
+        raise iu.IvyError(None,"Encountered error looking for \""
+            + str(tag) + "\" in database \"" + str(database) + "\": "
+            + str(e))
+    return False
 
-def decide(s,atoms=None):
+def addToDatabase(database, tag):
+    if database != None and tag != None:
+        try:
+            with open(database, 'a') as fw:
+                fw.write(tag)
+        except Exception as e:
+            raise iu.IvyError(None, "Encountered error writing \""
+                + str(tag) + "\" to database \"" + str(database) + "\": "
+                + str(e))
+    return
+
+def decide(s,atoms=None,database=None):
     # print "solving{"
-    # f = open("ivy.smt2","w")
-    # f.write(s.to_smt2())
-    # f.close()
+    tag = hash(s.to_smt2())
+    if databaseContains(database, tag):
+        return z3.unsat
     res = s.check() if atoms == None else s.check(atoms)
     if res == z3.unknown:
         print s.to_smt2()
         raise iu.IvyError(None,"Solver produced inconclusive result")
     # print "}"
+    if res == z3.unsat and database != None:
+        addToDatabase(database, tag)
     return res
 
-def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_cond=None, shrink=True):
+def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_cond=None, shrink=True, database=None):
     """
     Return a HerbrandModel with a "small" model of clauses.
 
@@ -1144,7 +1170,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
 #    iu.dbg('the_fmla')
     s.add(the_fmla)
     
-    # res = decide(s)
+    # res = decide(s, database=database)
     # if res == z3.unsat:
     #     return None
 
@@ -1178,7 +1204,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
                     the_fmla = clauses_to_z3(foo)
                     # iu.dbg('the_fmla')
                     s.add(the_fmla)
-                    res = decide(s)
+                    res = decide(s, database=database)
                     if res != z3.unsat:
                         if fc.sat():
                             res = z3.unsat
@@ -1190,9 +1216,9 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
                         s.pop()
         else:
             s.add(clauses_to_z3(final_cond))
-            res = decide(s)
+            res = decide(s, database=database)
     else:
-        res = decide(s)
+        res = decide(s, database=database)
     if res == z3.unsat:
         return None
 
@@ -1204,7 +1230,7 @@ def get_small_model(clauses, sorts_to_minimize, relations_to_minimize, final_con
                 s.push()
                 sc = size_constraint(x, n)
                 s.add(formula_to_z3(sc))
-                res = decide(s)
+                res = decide(s, database=database)
                 if res == z3.sat:
                     break
                 else:
@@ -1367,7 +1393,7 @@ def filter_redundant_facts(clauses,axioms):
         s2.add(c)
     keep = []
     for fmla,alit in zip(neg_fmlas,alits):
-        if decide(s2,[alit]) == z3.sat:
+        if decide(s2,atoms=[alit],database=database) == z3.sat:
             keep.append(fmla)
 #    print "unsat_core res = {}".format(res)
     return Clauses(pos_fmlas+keep,list(clauses.defs))

--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -1135,6 +1135,7 @@ def decide(s,atoms=None):
     # print "solving{"
     tag = hash(s.to_smt2())
     if databaseContains(tag):
+        print "Found s in database {}".format(database)
         return z3.unsat
     res = s.check() if atoms == None else s.check(atoms)
     if res == z3.unknown:

--- a/ivy/ivy_solver.py
+++ b/ivy/ivy_solver.py
@@ -38,17 +38,19 @@ def set_seed(seed):
 opt_seed = iu.Parameter("seed",0,process=int)
 opt_seed.set_callback(set_seed)
 
-database = None
 def set_database(db):
-    print 'using {} as a database of proven invariants'.format(db)
-    database = db
+    print 'Using {} as a database of proven invariants'.format(db)
 
 def check_db(db):
     try:
         with open(db, 'r') as fr:
             _ = fr.read()
     except:
-        return False
+        try:
+            with open(db, 'w') as fw:
+                pass
+        except:
+            return False
     return True
 
 opt_database = iu.Parameter("database",None,check_db)
@@ -1107,35 +1109,35 @@ def model_if_none(clauses1,implied,model):
     return h
 
 def databaseContains(tag):
-    if database == None or tag == None:
+    if opt_database.get() == None or tag == None:
         return False
     try:
-        with open(database, 'r') as fr:
+        with open(opt_database.get(), 'r') as fr:
             for line in fr:
                 if line.strip() == tag:
                     return True
     except Exception as e:
         raise iu.IvyError(None,"Encountered error looking for \""
-            + str(tag) + "\" in database \"" + str(database) + "\": "
+            + str(tag) + "\" in database \"" + str(opt_database.get()) + "\": "
             + str(e))
     return False
 
 def addToDatabase(tag):
-    if database != None and tag != None:
+    if opt_database.get() != None and tag != None and len(tag) > 0:
         try:
-            with open(database, 'a') as fw:
-                fw.write(tag)
+            with open(opt_database.get(), 'a') as fw:
+                fw.write(tag + "\n")
         except Exception as e:
             raise iu.IvyError(None, "Encountered error writing \""
-                + str(tag) + "\" to database \"" + str(database) + "\": "
+                + str(tag) + "\" to database \"" + str(opt_database.get()) + "\": "
                 + str(e))
     return
 
 def decide(s,atoms=None):
     # print "solving{"
-    tag = hash(s.to_smt2())
+    tag = str(hash(s.to_smt2()))
     if databaseContains(tag):
-        print "Found s in database {}".format(database)
+        print "(found in {}) ".format(opt_database.get()),
         return z3.unsat
     res = s.check() if atoms == None else s.check(atoms)
     if res == z3.unknown:

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ except:
   long_description = None
 
 setup(name='ms_ivy',
+      python_requires='<3',
       version='1.8.23',
       description='IVy verification tool',
       long_description=long_description,
@@ -35,7 +36,17 @@ setup(name='ms_ivy',
           'pydot',
       ] + (['applescript'] if platform.system() == 'Darwin' else []),
       entry_points = {
-        'console_scripts': ['ivy=ivy.ivy:main','ivy_check=ivy.ivy_check:main','ivy_to_cpp=ivy.ivy_to_cpp:main','ivy_show=ivy.ivy_show:main','ivy_ev_viewer=ivy.ivy_ev_viewer:main','ivyc=ivy.ivy_to_cpp:ivyc','ivy_to_md=ivy.ivy_to_md:main','ivy_libs=ivy.ivy_libs:main','ivy_shell=ivy.ivy_shell:main','ivy_launch=ivy.ivy_launch:main'],
+        'console_scripts': [
+            'ivy=ivy.ivy:main',
+            'ivy_check=ivy.ivy_check:main',
+            'ivy_to_cpp=ivy.ivy_to_cpp:main',
+            'ivy_show=ivy.ivy_show:main',
+            'ivy_ev_viewer=ivy.ivy_ev_viewer:main',
+            'ivyc=ivy.ivy_to_cpp:ivyc',
+            'ivy_to_md=ivy.ivy_to_md:main',
+            'ivy_libs=ivy.ivy_libs:main',
+            'ivy_shell=ivy.ivy_shell:main',
+            'ivy_launch=ivy.ivy_launch:main'],
         },
       zip_safe=False)
 


### PR DESCRIPTION
This pull request makes the following changes.

1. Adds an optional `database` parameter.  Setting `database=my-file.txt` tells the code to use `my-file.txt` as a data-base.  The database works like a cache of failed SMT formulae, namely, failed negations of invariants or assertions.  The idea is to achieve a speed-up by caching computations done when checking the model before you added or removed an invariant, sort of like how in Coq some portion of your proof will be green and won't need to be re-evaluated just to check the next portion you write.  
2. Colors `PASS` green, `FAIL` red, and `[assumed]` blue (will behave slightly differently depending on your terminal theme).  This improves overall legibility.

![found-in-db](https://user-images.githubusercontent.com/4683443/174410184-b7c19fa6-0cf0-43f6-8e55-a30f266b7fe0.png)
