### PR TITLE
Fix two small typos

### DIFF
--- a/doc/examples/values.md
+++ b/doc/examples/values.md
@@ -91,7 +91,7 @@ Here is an example of a simple program that tabulates the function
     instance arr : array(t,t)
 
     action tabulate(max : t) returns (res:arr.t) {
-        local i:index {
+        local i:t {
             i := 0;
             res := arr.create(max,0);
             while i < max {

--- a/doc/language.md
+++ b/doc/language.md
@@ -61,7 +61,7 @@ Every Ivy file begins with a line like the following:
 This tells Ivy what version of the language we are using. This is
 important because in successive version of the language, certain
 features may be changed or deprecated. Providing the language version
-allows old programs to keep working. They current version of the Ivy
+allows old programs to keep working. The current version of the Ivy
 language is 1.7. Changes between versions of the language are listed
 at the end of this document.
 


### PR DESCRIPTION
* Fix a word in `doc/language.md`
* Correct an example in `doc/examples/values.md`