### PR TITLE
Keyval find specs

### DIFF
--- a/ivy/include/1.8/collections.ivy
+++ b/ivy/include/1.8/collections.ivy
@@ -1463,6 +1463,10 @@ module keyval(index,key,data) = {
             assert key_at(old s,I,X) -> value_at(s,I) = value_at(old s,I);
             assert value_at(s,end(old s)) = d
         }
+        after find {
+            assert  (exists I. s.key_at(I, k)) ->   key_at(s,i,k);
+            assert ~(exists I. s.key_at(I, k)) ->  ~key_at(s,i,k) & end(s) <= i;
+        }
     }
 
     object impl = {
@@ -1509,9 +1513,13 @@ module keyval(index,key,data) = {
         implement find {
             i := repr(s).begin;
             var end := repr(s).end;
-            while i < end & repr(s).value(i).p_key ~= k {
+            while i < end & repr(s).value(i).p_key ~= k
+            invariant  (exists I. s.key_at(I, k)) ->  (exists I. i <= I & I < end & s.key_at(I, k))
+            invariant ~(exists I. s.key_at(I, k)) -> ~(exists I. i <= I & I < end & s.key_at(I, k))
+            {
                 i := i.next;
             }
+            assert end <= i | repr(s).value(i).p_key = k;
         }
         
         implement remove {


### PR DESCRIPTION
Added specs for `find` to state that the return value `i` either refers to the correct index for the given key `k`, or refers to a value outside of the assigned indexes.

Test file `test.ivy`:
```
#lang ivy1.8

include collections

instance k : unbounded_sequence
instance v : unbounded_sequence
instance kv : keyval(index, k, v)

export kv.find
```
Test command:
```
$ ivy_check isolate=kv.iso test.ivy
```

--- 

I've written the postcondition for `find` using implications to separate the two cases. I'm not sure if that's the right approach.