### PR TITLE
Fix a variable name shadowing a module name.

### DIFF
--- a/ivy/ivy_compiler.py
+++ b/ivy/ivy_compiler.py
@@ -2236,9 +2236,9 @@ def ivy_compile(decls,mod=None,create_isolate=True,**kwargs):
                 pp,pc = iu.parent_child_name(p)
                 if pp == 'this' or iu.compose_names(pp,'global') not in im.module.attributes:
                     global_objects.append(ivy_ast.Atom(p,[]))
-        for iso in list(im.module.isolates.values()):
-            iso.args += tuple(global_objects)
-            iso.with_args += len(global_objects)
+        for mod_iso in list(im.module.isolates.values()):
+            mod_iso.args += tuple(global_objects)
+            mod_iso.with_args += len(global_objects)
                     
 
         create_sort_order(mod)


### PR DESCRIPTION
This leads to the example in the installation failing, as described in https://github.com/kenmcmil/ivy/issues/44

"iso" is an alias for the `ivy_isolate` module.