### PR TITLE
With `ivy_check trace=true` output variables in alphabetical order

### DIFF
--- a/ivy/ivy_trace.py
+++ b/ivy/ivy_trace.py
@@ -165,7 +165,7 @@ class TraceBase(art.AnalysisGraph):
                 foo = False
                 if hasattr(state,"loop_start") and state.loop_start:
                     lines.append('\n--- the following repeats infinitely ---\n\n')
-                for c in state.clauses.fmlas:
+                for c in sorted(state.clauses.fmlas, key=str):
                     if hidden(c.args[0].rep):
                         continue
                     if renaming is not None:


### PR DESCRIPTION
When printing out variables in the `ivy_check trace=true` output, this change makes variables print in alphabetical order. This is helpful since all the nested structures are output at the same level with `.` delimited paths in their names, making it hard to locate a single nested structure when the output is not sorted.

## Before
```
searching for a small model... done
[
    0:index < 0 = false
    pid.iter.val(0) = 0
    vc.kv.end(0) = 0
    vc.repr(0) = 0
    0:index = 0
    index.succ(0,0) = false
    pid.iter.is_end(0) = true
    vc.kv.key_at(0,0,0) = false
]
```
The nested structures `pid.iter.*` and `vc.kv.*` aren't obvious.
## After
```
searching for a small model... done
[
    0:index < 0 = false
    0:index = 0
    index.succ(0,0) = false
    pid.iter.is_end(0) = true
    pid.iter.val(0) = 0
    vc.kv.end(0) = 0
    vc.kv.key_at(0,0,0) = false
    vc.repr(0) = 0
]
```
Both nested structures' properties are grouped together.

cc @nano-o